### PR TITLE
Cosmetic Changes and UI Improvements

### DIFF
--- a/alarmserver/alarmserver.cfg
+++ b/alarmserver/alarmserver.cfg
@@ -20,7 +20,7 @@ logurlrequests=True
 #keyfile=
 
 ## Maximum number of events to display for each zone
-maxevents=15
+maxevents=10
 
 ## Total number of events to show for all the zones combined
 maxallevents=100
@@ -45,6 +45,8 @@ eventtimeago=True
 ## ${callbackurl_base}/${callbackurl_app_id}/panel/${code}/${zoneorpartitionnumber}?access_token=${callbackurl_access_token}
 
 ## Smartthings or generic callback URL setup
+## Check to make sure that when you are logged in to https://graph.api.smartthings.com that your URL prefix is not
+## something else like https://graph-na02-useast1.api.smartthings.com
 callbackurl_base=https://graph.api.smartthings.com/api/smartapps/installations
 callbackurl_app_id=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 callbackurl_access_token=xxxxxxxxxxxxxxxxxxxxxxxxxxx
@@ -86,35 +88,18 @@ stay=Alarm Stay Panel
 name=Front Door
 type=contact
 [zone2]
-name=Garage Door
+name=Upstairs Window
 type=contact
 [zone3]
-name=Patio Door
-type=contact
+name=Main Floor Motion
+type=motion
 [zone4]
-name=Master Windows
+name=Smoke Detector
 type=contact
 [zone5]
-name=Downstairs Windows
+name=Carbon Monoxide Detector
 type=contact
+## This could be something like the DSC WS4985
 [zone6]
-name=Upstairs Windows
-type=contact
-[zone9]
-name=B Room
-type=contact
-[zone10]
-name=A Room
-type=contact
-[zone11]
-name=Guest Room
-type=contact
-[zone12]
-name=Upstairs Bathroom
-type=contact
-#[zone3]
-#name=DSC Zone 03 Patio Door   
-#type=motion
-#[zone4]
-#name=DSC Zone 04 Patio Door
-#type=co
+name=Sump Pump Water Sensor
+type=flood

--- a/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
+++ b/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
@@ -3,8 +3,8 @@
  *
  *  Author: Jordan <jordan@xeron.cc
  *  Original Code By: Rob Fisher <robfish@att.net>, Carlos Santiago <carloss66@gmail.com>, JTT <aesystems@gmail.com>
- *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  *  Date: 2016-02-03
+ *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
  // for the UI
 

--- a/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
+++ b/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
@@ -3,13 +3,14 @@
  *
  *  Author: Jordan <jordan@xeron.cc
  *  Original Code By: Rob Fisher <robfish@att.net>, Carlos Santiago <carloss66@gmail.com>, JTT <aesystems@gmail.com>
+ *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  *  Date: 2016-02-03
  */
  // for the UI
 
 metadata {
     // Automatically generated. Make future change here.
-    definition (name: "DSC Away Panel", author: "Jordan <jordan@xeron.cc>", namespace: 'dsc') {
+    definition (name: "DSC Away Panel", author: "Jordan <jordan@xeron.cc>", namespace: 'DSC') {
         capability "Switch"
         capability "Refresh"
 
@@ -35,97 +36,62 @@ metadata {
 
     // UI tile definitions
     tiles(scale: 2) {
-      standardTile ("status", "device.status", width: 4, height: 4, title: "Status") {
-        state "alarm", label:'Alarm', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
-        state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#800000"
-        state "disarm", label:'Disarmed', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        state "duress", label:'Duress', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
-        state "entrydelay", label:'Entry Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-        state "exitdelay", label:'Exit Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-        state "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
-        state "ready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        state "forceready", label:'Ready - F', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        state "stay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#008CC1"
-        state "instantaway", label:'Armed Instant Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#800000"
-        state "instantstay", label:'Armed Instant Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#008CC1"
+    	multiAttributeTile(name:"status", type: "general", width: 6, height: 4){
+     	   tileAttribute ("device.status", key: "PRIMARY_CONTROL") {
+				attributeState "alarm", label:'Alarming', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+				attributeState "away", label:'Armed Away', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+				attributeState "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+				attributeState "duress", label:'Duress', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+				attributeState "entrydelay", label:'Entry Delay', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+                attributeState "exitdelay", label:'Exit Delay', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+                attributeState "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
+                attributeState "ready", label:'Ready', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+                attributeState "forceready", label:'Ready', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+                attributeState "stay", label:'Armed Stay', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+                attributeState "instantaway", label:'Armed Away', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+                attributeState "instantstay", label:'Armed Stay', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+           }
+		}
+        
+        // This title is just a hidden title for use in the "Things" lists
+        standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
+        	state "alarm", label:'Alarming', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+        	state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+        	state "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+        	state "duress", label:'Duress', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+        	state "entrydelay", label:'Entry Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+        	state "exitdelay", label:'Exit Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+        	state "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
+        	state "ready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+        	state "forceready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+        	state "stay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+        	state "instantaway", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+        	state "instantstay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+       }
+      standardTile("away", "capability.momentary", width: 2, height: 2, title: "Away", decoration: "flat"){
+        state "away", label: 'Away', action: "away", icon: "st.presence.car.car", backgroundColor: "#6666FF"
+      }
+      standardTile("stay", "capability.momentary", width: 2, height: 2, title: "Stay", decoration: "flat"){
+        state "stay", label: 'Stay', action: "stay", icon: "st.presence.house.secured", backgroundColor: "#00A0DC"
+      }
+      standardTile("disarm", "capability.momentary", width: 2, height: 2, title: "Disarm", decoration: "flat"){
+        state "disarm", label: 'Disarm', action: "disarm", icon: "st.presence.house.unlocked", backgroundColor: "#79b821"
       }
       standardTile("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
         state "detected", label: 'Trouble', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
-        state "clear", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear", backgroundColor: "#79b821"
+        state "clear", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear"
       }
-      standardTile("chime", "device.chime", width: 2, height: 2, title: "Chime"){
-        state "togglechime", label: 'Toggling\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep", backgroundColor: "#fbd48a"
-        state "chime", label: 'Chime', action: "togglechime", icon: "st.alarm.beep.beep", backgroundColor: "#EE9D00"
-        state "nochime", label: 'No\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep", backgroundColor: "#796338"
-      }
-      standardTile("disarm", "capability.momentary", width: 2, height: 2, title: "Disarm"){
-        state "disarm", label: 'Disarm', action: "disarm", icon: "st.presence.house.unlocked", backgroundColor: "#79b821"
-      }
-      standardTile("away", "capability.momentary", width: 2, height: 2, title: "Away"){
-        state "away", label: 'Away', action: "away", icon: "st.presence.car.car", backgroundColor: "#800000"
-      }
-      standardTile("stay", "capability.momentary", width: 2, height: 2, title: "Stay"){
-        state "stay", label: 'Stay', action: "stay", icon: "st.presence.house.secured", backgroundColor: "#008CC1"
-      }
-      standardTile("instant", "capability.momentary", width: 2, height: 2, title: "Instant"){
-        state "instant", label: 'Instant', action: "instant", icon: "st.locks.lock.locked", backgroundColor: "#00FF00"
-      }
-      standardTile("night", "capability.momentary", width: 2, height: 2, title: "Night"){
-        state "night", label: 'Night', action: "night", icon: "st.Bedroom.bedroom2", backgroundColor: "#AA00FF"
-      }
-      standardTile("reset", "capability.momentary", width: 2, height: 2, title: "Sensor Reset"){
-        state "reset", label: 'Sensor\u00A0Reset', action: "reset", icon: "st.alarm.smoke.smoke", backgroundColor: "#FF3000"
-      }
-      standardTile("bypassoff", "capability.momentary", width: 2, height: 2, title: "Bypass Off"){
-        state "bypassoff", label: 'Bypass\u00A0Off', action: "bypassoff", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
-      }
-      valueTile("ledready", "device.ledready", width: 2, height: 1){
-        state "ledready", label:'Ready: ${currentValue}'
-      }
-      valueTile("ledarmed", "device.ledarmed", width: 2, height: 1){
-        state "ledarmed", label:'Armed: ${currentValue}'
-      }
-      valueTile("ledmemory", "device.ledmemory", width: 2, height: 1){
-        state "ledmemory", label:'Memory: ${currentValue}'
-      }
-      valueTile("ledbypass", "device.ledbypass", width: 2, height: 1){
-        state "ledbypass", label:'Bypass: ${currentValue}'
-      }
-      valueTile("ledtrouble", "device.ledtrouble", width: 2, height: 1){
-        state "ledtrouble", label:'Trouble: ${currentValue}'
-      }
-      valueTile("ledprogram", "device.ledprogram", width: 2, height: 1){
-        state "ledprogram", label:'Program: ${currentValue}'
-      }
-      valueTile("ledfire", "device.ledfire", width: 2, height: 1){
-        state "ledfire", label:'Fire: ${currentValue}'
-      }
-      valueTile("ledbacklight", "device.ledbacklight", width: 2, height: 1){
-        state "ledbacklight", label:'Backlight: ${currentValue}'
-      }
-      standardTile("key", "device.key", width: 2, height: 2, title: "Key"){
-        state "nokey", label: 'Alarm\u00A0Keys\u00A0Off', action: "key", icon: "st.illuminance.illuminance.dark", backgroundColor: "#7B3516", defaultState: true
-        state "key", label: 'Alarm\u00A0Keys\u00A0On', action: "nokey", icon: "st.illuminance.illuminance.light", backgroundColor: "#FF6E2E"
-      }
-      standardTile("keyfire", "device.keyfire", width: 2, height: 2, title: "Fire Key"){
-        state "restore", label: 'Fire\u00A0Key', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
-        state "alarm", label: 'Fire\u00A0Key\u00A0Alarm', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
-      }
-      standardTile("keyaux", "device.keyaux", width: 2, height: 2, title: "Aux Key"){
-        state "restore", label: 'Aux\u00A0Key', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
-        state "alarm", label: 'Aux\u00A0Key\u00A0Alarm', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
-      }
-      standardTile("keypanic", "device.keypanic", width: 2, height: 2, title: "Panic Key"){
-        state "restore", label: 'Panic\u00A0Key', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
-        state "alarm", label: 'Panic\u00A0Key\u00A0Alarm', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
+      standardTile("chime", "device.chime", width: 2, height: 2, title: "Chime", decoration: "flat"){
+        state "togglechime", label: 'Toggling\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#fbd48a"
+        state "chime", label: 'Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#EE9D00"
+        state "nochime", label: 'No\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#796338"
       }
       standardTile("refresh", "device.refresh", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
         state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
       }
 
-
-      main "status"
-      details(["status", "trouble", "chime", "away", "stay", "disarm", "instant", "night", "reset", "bypassoff", "ledready", "ledarmed", "ledmemory", "ledbypass", "key", "ledtrouble", "ledprogram", "ledfire", "ledbacklight", "keyfire", "keyaux", "keypanic", "refresh"])
+      main "statusHidden"
+      details(["status", "away", "stay", "disarm", "trouble", "chime", "refresh"])
     }
 }
 

--- a/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
+++ b/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
@@ -6,7 +6,7 @@
  *  Date: 2016-02-03
  *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
- // for the UIW
+ // for the UI
 
 metadata {
 	// Automatically generated. Make future change here.

--- a/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
+++ b/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
@@ -53,8 +53,8 @@ metadata {
 			}
 		}
         
-        	// This title is just a hidden title for use in the "Things" lists
-        	standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
+    // This title is just a hidden title for use in the "Things" lists
+  	standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
 			state "alarm", label:'Alarming', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
 			state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
 			state "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"

--- a/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
+++ b/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
@@ -6,7 +6,7 @@
  *  Date: 2016-02-03
  *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
- // for the UI
+ // for the UIW
 
 metadata {
 	// Automatically generated. Make future change here.

--- a/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
+++ b/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
@@ -9,90 +9,142 @@
  // for the UI
 
 metadata {
-    // Automatically generated. Make future change here.
-    definition (name: "DSC Away Panel", author: "Jordan <jordan@xeron.cc>", namespace: 'DSC') {
-        capability "Switch"
-        capability "Refresh"
+	// Automatically generated. Make future change here.
+	definition (name: "DSC Away Panel", author: "Jordan <jordan@xeron.cc>", namespace: 'DSC') {
+		capability "Switch"
+		capability "Refresh"
 
-        command "away"
-        command "bypassoff"
-        command "disarm"
-        command "instant"
-        command "night"
-        command "nokey"
-        command "partition"
-        command "key"
-        command "keyfire"
-        command "keyaux"
-        command "keypanic"
-        command "reset"
-        command "stay"
-        command "togglechime"
-    }
+		command "away"
+		command "bypassoff"
+		command "disarm"
+		command "instant"
+		command "night"
+		command "nokey"
+		command "partition"
+		command "key"
+		command "keyfire"
+		command "keyaux"
+		command "keypanic"
+		command "reset"
+		command "stay"
+		command "togglechime"
+	}
 
-    // simulator metadata
-    simulator {
-    }
+	// simulator metadata
+	simulator {
+	}
 
-    // UI tile definitions
-    tiles(scale: 2) {
-    	multiAttributeTile(name:"status", type: "general", width: 6, height: 4){
-     	   tileAttribute ("device.status", key: "PRIMARY_CONTROL") {
+    	// UI tile definitions
+	tiles(scale: 2) {
+		multiAttributeTile(name:"status", type: "general", width: 6, height: 4){
+			tileAttribute ("device.status", key: "PRIMARY_CONTROL") {
 				attributeState "alarm", label:'Alarming', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
 				attributeState "away", label:'Armed Away', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
 				attributeState "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"
 				attributeState "duress", label:'Duress', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
 				attributeState "entrydelay", label:'Entry Delay', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-                attributeState "exitdelay", label:'Exit Delay', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-                attributeState "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
-                attributeState "ready", label:'Ready', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-                attributeState "forceready", label:'Ready', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-                attributeState "stay", label:'Armed Stay', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
-                attributeState "instantaway", label:'Armed Away', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
-                attributeState "instantstay", label:'Armed Stay', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
-           }
+				attributeState "exitdelay", label:'Exit Delay', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+				attributeState "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
+				attributeState "ready", label:'Ready', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+				attributeState "forceready", label:'Ready', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+				attributeState "stay", label:'Armed Stay', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+				attributeState "instantaway", label:'Armed Away', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+				attributeState "instantstay", label:'Armed Stay', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+			}
 		}
         
-        // This title is just a hidden title for use in the "Things" lists
-        standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
-        	state "alarm", label:'Alarming', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
-        	state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
-        	state "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        	state "duress", label:'Duress', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
-        	state "entrydelay", label:'Entry Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-        	state "exitdelay", label:'Exit Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-        	state "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
-        	state "ready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        	state "forceready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        	state "stay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
-        	state "instantaway", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
-        	state "instantstay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
-       }
-      standardTile("away", "capability.momentary", width: 2, height: 2, title: "Away", decoration: "flat"){
-        state "away", label: 'Away', action: "away", icon: "st.presence.car.car", backgroundColor: "#6666FF"
-      }
-      standardTile("stay", "capability.momentary", width: 2, height: 2, title: "Stay", decoration: "flat"){
-        state "stay", label: 'Stay', action: "stay", icon: "st.presence.house.secured", backgroundColor: "#00A0DC"
-      }
-      standardTile("disarm", "capability.momentary", width: 2, height: 2, title: "Disarm", decoration: "flat"){
-        state "disarm", label: 'Disarm', action: "disarm", icon: "st.presence.house.unlocked", backgroundColor: "#79b821"
-      }
-      standardTile("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-        state "detected", label: 'Trouble', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
-        state "clear", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear"
-      }
-      standardTile("chime", "device.chime", width: 2, height: 2, title: "Chime", decoration: "flat"){
-        state "togglechime", label: 'Toggling\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#fbd48a"
-        state "chime", label: 'Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#EE9D00"
-        state "nochime", label: 'No\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#796338"
-      }
-      standardTile("refresh", "device.refresh", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-        state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
-      }
+        	// This title is just a hidden title for use in the "Things" lists
+        	standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
+			state "alarm", label:'Alarming', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+			state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+			state "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+			state "duress", label:'Duress', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+			state "entrydelay", label:'Entry Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+			state "exitdelay", label:'Exit Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+			state "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
+			state "ready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+			state "forceready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+			state "stay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+			state "instantaway", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+			state "instantstay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+		}
+		standardTile("away", "capability.momentary", width: 2, height: 2, title: "Away", decoration: "flat"){
+			state "away", label: 'Away', action: "away", icon: "st.presence.car.car", backgroundColor: "#6666FF"
+		}
+		standardTile("stay", "capability.momentary", width: 2, height: 2, title: "Stay", decoration: "flat"){
+			state "stay", label: 'Stay', action: "stay", icon: "st.presence.house.secured", backgroundColor: "#00A0DC"
+		}
+		standardTile("disarm", "capability.momentary", width: 2, height: 2, title: "Disarm", decoration: "flat"){
+			state "disarm", label: 'Disarm', action: "disarm", icon: "st.presence.house.unlocked", backgroundColor: "#79b821"
+		}
+		standardTile("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
+			state "detected", label: 'Trouble', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
+			state "clear", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear"
+		}
+		standardTile("chime", "device.chime", width: 2, height: 2, title: "Chime", decoration: "flat"){
+			state "togglechime", label: 'Toggling\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#fbd48a"
+			state "chime", label: 'Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#EE9D00"
+			state "nochime", label: 'No\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#796338"
+		}
+		standardTile("refresh", "device.refresh", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
+			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
+		}
+		//standardTile("instant", "capability.momentary", width: 2, height: 2, title: "Instant"){
+			//state "instant", label: 'Instant', action: "instant", icon: "st.locks.lock.locked", backgroundColor: "#00FF00"
+		//}
+		//standardTile("night", "capability.momentary", width: 2, height: 2, title: "Night"){
+			//state "night", label: 'Night', action: "night", icon: "st.Bedroom.bedroom2", backgroundColor: "#AA00FF"
+		//}
+		//standardTile("reset", "capability.momentary", width: 2, height: 2, title: "Sensor Reset"){
+			//state "reset", label: 'Sensor\u00A0Reset', action: "reset", icon: "st.alarm.smoke.smoke", backgroundColor: "#FF3000"
+		//}
+		//standardTile("bypassoff", "capability.momentary", width: 2, height: 2, title: "Bypass Off"){
+			//state "bypassoff", label: 'Bypass\u00A0Off', action: "bypassoff", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
+		//}
+		//valueTile("ledready", "device.ledready", width: 2, height: 1){
+			//state "ledready", label:'Ready: ${currentValue}'
+		//}
+		//valueTile("ledarmed", "device.ledarmed", width: 2, height: 1){
+			//state "ledarmed", label:'Armed: ${currentValue}'
+		//}
+		//valueTile("ledmemory", "device.ledmemory", width: 2, height: 1){
+			//state "ledmemory", label:'Memory: ${currentValue}'
+		//}
+		//valueTile("ledbypass", "device.ledbypass", width: 2, height: 1){
+			//state "ledbypass", label:'Bypass: ${currentValue}'
+		//}
+		//valueTile("ledtrouble", "device.ledtrouble", width: 2, height: 1){
+			//state "ledtrouble", label:'Trouble: ${currentValue}'
+		//}
+		//valueTile("ledprogram", "device.ledprogram", width: 2, height: 1){
+			//state "ledprogram", label:'Program: ${currentValue}'
+		//}
+		//valueTile("ledfire", "device.ledfire", width: 2, height: 1){
+			//state "ledfire", label:'Fire: ${currentValue}'
+		//}
+		//valueTile("ledbacklight", "device.ledbacklight", width: 2, height: 1){
+			//state "ledbacklight", label:'Backlight: ${currentValue}'
+		//}
+		//standardTile("key", "device.key", width: 2, height: 2, title: "Key"){
+			//state "nokey", label: 'Alarm\u00A0Keys\u00A0Off', action: "key", icon: "st.illuminance.illuminance.dark", backgroundColor: "#7B3516", defaultState: true
+			//state "key", label: 'Alarm\u00A0Keys\u00A0On', action: "nokey", icon: "st.illuminance.illuminance.light", backgroundColor: "#FF6E2E"
+		//}
+		//standardTile("keyfire", "device.keyfire", width: 2, height: 2, title: "Fire Key"){
+			//state "restore", label: 'Fire\u00A0Key', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
+			//state "alarm", label: 'Fire\u00A0Key\u00A0Alarm', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
+		//}
+		//standardTile("keyaux", "device.keyaux", width: 2, height: 2, title: "Aux Key"){
+			//state "restore", label: 'Aux\u00A0Key', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
+			//state "alarm", label: 'Aux\u00A0Key\u00A0Alarm', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
+		//}
+		//standardTile("keypanic", "device.keypanic", width: 2, height: 2, title: "Panic Key"){
+			//state "restore", label: 'Panic\u00A0Key', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
+			//state "alarm", label: 'Panic\u00A0Key\u00A0Alarm', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
+		//}
 
-      main "statusHidden"
-      details(["status", "away", "stay", "disarm", "trouble", "chime", "refresh"])
-    }
+		main "statusHidden"
+		details(["status", "away", "stay", "disarm", "trouble", "chime", "refresh"])
+	}
 }
 
 def partition(String state, String partition, Map parameters) {

--- a/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
+++ b/devicetypes/dsc/dsc-away-panel.src/dsc-away-panel.groovy
@@ -148,114 +148,119 @@ metadata {
 }
 
 def partition(String state, String partition, Map parameters) {
-  // state will be a valid state for the panel (ready, notready, armed, etc)
-  // partition will be a partition number, for most users this will always be 1
+	// state will be a valid state for the panel (ready, notready, armed, etc)
+	// partition will be a partition number, for most users this will always be 1
 
-  log.debug "Partition: ${state} for partition: ${partition}"
+	log.debug "Partition: ${state} for partition: ${partition}"
 
-  def onList = ['alarm','away','entrydelay','exitdelay','instantaway']
+	def onList = ['alarm','away','entrydelay','exitdelay','instantaway']
 
-  def chimeList = ['chime','nochime']
+	def chimeList = ['chime','nochime']
 
-  def troubleMap = [
-    'trouble':"detected",
-    'restore':"clear",
-  ]
+	def troubleMap = [
+		'trouble':"detected",
+		'restore':"clear",
+	]
 
-  if (onList.contains(state)) {
-    sendEvent (name: "switch", value: "on")
-  } else if (!(chimeList.contains(state) || troubleMap[state] || state.startsWith('led') || state.startsWith('key'))) {
-    sendEvent (name: "switch", value: "off")
-  }
+	if (onList.contains(state)) {
+		sendEvent (name: "switch", value: "on")
+	} 
+	else if (!(chimeList.contains(state) || troubleMap[state] || state.startsWith('led') || state.startsWith('key'))) {
+		sendEvent (name: "switch", value: "off")
+	}
 
-  if (troubleMap[state]) {
-    def troubleState = troubleMap."${state}"
-    // Send trouble event
-    sendEvent (name: "trouble", value: "${troubleState}")
-  } else if (chimeList.contains(state)) {
-    // Send chime event
-    sendEvent (name: "chime", value: "${state}")
-  } else if (state.startsWith('led')) {
-    def flash = (state.startsWith('ledflash')) ? 'flash ' : ''
-    for (p in parameters) {
-      sendEvent (name: "led${p.key}", value: "${flash}${p.value}")
-    }
-  } else if (state.startsWith('key')) {
-    def name = state.minus('alarm').minus('restore')
-    def value = state.replaceAll(/.*(alarm|restore)/, '$1')
-    sendEvent (name: "${name}", value: "${value}")
-  } else {
-    // Send final event
-    sendEvent (name: "status", value: "${state}")
-  }
+	if (troubleMap[state]) {
+		def troubleState = troubleMap."${state}"
+		// Send trouble event
+		sendEvent (name: "trouble", value: "${troubleState}")
+	} 
+	else if (chimeList.contains(state)) {
+		// Send chime event
+		sendEvent (name: "chime", value: "${state}")
+	} 
+	else if (state.startsWith('led')) {
+		def flash = (state.startsWith('ledflash')) ? 'flash ' : ''
+		for (p in parameters) {
+			sendEvent (name: "led${p.key}", value: "${flash}${p.value}")
+		}
+	} 
+	else if (state.startsWith('key')) {
+		def name = state.minus('alarm').minus('restore')
+		def value = state.replaceAll(/.*(alarm|restore)/, '$1')
+		sendEvent (name: "${name}", value: "${value}")
+	} 
+	else {
+		// Send final event
+		sendEvent (name: "status", value: "${state}")
+	}
 }
 
 def away() {
-  parent.sendUrl('arm')
+	parent.sendUrl('arm')
 }
 
 def bypassoff() {
-  parent.sendUrl("bypass?zone=0")
+	parent.sendUrl("bypass?zone=0")
 }
 
 def disarm() {
-  parent.sendUrl('disarm')
+	parent.sendUrl('disarm')
 }
 
 def instant() {
-  parent.sendUrl('toggleinstant')
+	parent.sendUrl('toggleinstant')
 }
 
 def night() {
-  parent.sendUrl('togglenight')
+	parent.sendUrl('togglenight')
 }
 
 def nokey() {
-  sendEvent (name: "key", value: "nokey")
+	sendEvent (name: "key", value: "nokey")
 }
 
 def on() {
-  away()
+	away()
 }
 
 def off() {
-  disarm()
+	disarm()
 }
 
 def key() {
-  sendEvent (name: "key", value: "key")
+	sendEvent (name: "key", value: "key")
 }
 
 def keyfire() {
-  if ("${device.currentValue("key")}" == 'key') {
-    parent.sendUrl('panic?type=1')
-  }
+	if ("${device.currentValue("key")}" == 'key') {
+		parent.sendUrl('panic?type=1')
+	}
 }
 
 def keyaux() {
-  if ("${device.currentValue("key")}" == 'key') {
-    parent.sendUrl('panic?type=2')
-  }
+	if ("${device.currentValue("key")}" == 'key') {
+		parent.sendUrl('panic?type=2')
+	}
 }
 
 def keypanic() {
-  if ("${device.currentValue("key")}" == 'key') {
-    parent.sendUrl('panic?type=3')
-  }
+	if ("${device.currentValue("key")}" == 'key') {
+		parent.sendUrl('panic?type=3')
+	}
 }
 
 def refresh() {
-  parent.sendUrl('refresh')
+	parent.sendUrl('refresh')
 }
 
 def reset() {
-  parent.sendUrl('reset')
+	parent.sendUrl('reset')
 }
 
 def stay() {
-  parent.sendUrl('stayarm')
+	parent.sendUrl('stayarm')
 }
 
 def togglechime() {
-  parent.sendUrl('togglechime')
+	parent.sendUrl('togglechime')
 }

--- a/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
+++ b/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
@@ -148,114 +148,119 @@ metadata {
 }
 
 def partition(String state, String partition, Map parameters) {
-  // state will be a valid state for the panel (ready, notready, armed, etc)
-  // partition will be a partition number, for most users this will always be 1
+	// state will be a valid state for the panel (ready, notready, armed, etc)
+	// partition will be a partition number, for most users this will always be 1
 
-  log.debug "Partition: ${state} for partition: ${partition}"
+	log.debug "Partition: ${state} for partition: ${partition}"
 
-  def onList = ['alarm','entrydelay','exitdelay','instantstay','stay']
+	def onList = ['alarm','entrydelay','exitdelay','instantstay','stay']
 
-  def chimeList = ['chime','nochime']
+	def chimeList = ['chime','nochime']
 
-  def troubleMap = [
-    'trouble':"detected",
-    'restore':"clear",
-  ]
+	def troubleMap = [
+		'trouble':"detected",
+		'restore':"clear",
+  	]
 
-  if (onList.contains(state)) {
-    sendEvent (name: "switch", value: "on")
-  } else if (!(chimeList.contains(state) || troubleMap[state] || state.startsWith('led') || state.startsWith('key'))) {
-    sendEvent (name: "switch", value: "off")
-  }
+	if (onList.contains(state)) {
+		sendEvent (name: "switch", value: "on")
+	} 
+	else if (!(chimeList.contains(state) || troubleMap[state] || state.startsWith('led') || state.startsWith('key'))) {
+		sendEvent (name: "switch", value: "off")
+	}
 
-  if (troubleMap[state]) {
-    def troubleState = troubleMap."${state}"
-    // Send trouble event
-    sendEvent (name: "trouble", value: "${troubleState}")
-  } else if (chimeList.contains(state)) {
-    // Send chime event
-    sendEvent (name: "chime", value: "${state}")
-  } else if (state.startsWith('led')) {
-    def flash = (state.startsWith('ledflash')) ? 'flash ' : ''
-    for (p in parameters) {
-      sendEvent (name: "led${p.key}", value: "${flash}${p.value}")
-    }
-  } else if (state.startsWith('key')) {
-    def name = state.minus('alarm').minus('restore')
-    def value = state.replaceAll(/.*(alarm|restore)/, '$1')
-    sendEvent (name: "${name}", value: "${value}")
-  } else {
-    // Send final event
-    sendEvent (name: "status", value: "${state}")
-  }
+	if (troubleMap[state]) {
+		def troubleState = troubleMap."${state}"
+		// Send trouble event
+		sendEvent (name: "trouble", value: "${troubleState}")
+	} 
+	else if (chimeList.contains(state)) {
+		// Send chime event
+		sendEvent (name: "chime", value: "${state}")
+	} 
+	else if (state.startsWith('led')) {
+		def flash = (state.startsWith('ledflash')) ? 'flash ' : ''
+		for (p in parameters) {
+			sendEvent (name: "led${p.key}", value: "${flash}${p.value}")
+		}
+	} 
+	else if (state.startsWith('key')) {
+		def name = state.minus('alarm').minus('restore')
+		def value = state.replaceAll(/.*(alarm|restore)/, '$1')
+		sendEvent (name: "${name}", value: "${value}")
+	} 
+	else {
+		// Send final event
+		sendEvent (name: "status", value: "${state}")
+	}
 }
 
 def away() {
-  parent.sendUrl('arm')
+	parent.sendUrl('arm')
 }
 
 def bypassoff() {
-  parent.sendUrl("bypass?zone=0")
+	parent.sendUrl("bypass?zone=0")
 }
 
 def disarm() {
-  parent.sendUrl('disarm')
+	parent.sendUrl('disarm')
 }
 
 def instant() {
-  parent.sendUrl('toggleinstant')
+	parent.sendUrl('toggleinstant')
 }
 
 def night() {
-  parent.sendUrl('togglenight')
+	parent.sendUrl('togglenight')
 }
 
 def nokey() {
-  sendEvent (name: "key", value: "nokey")
+	sendEvent (name: "key", value: "nokey")
 }
 
 def on() {
-  stay()
+	stay()
 }
 
 def off() {
-  disarm()
+	disarm()
 }
 
 def key() {
-  sendEvent (name: "key", value: "key")
+	sendEvent (name: "key", value: "key")
 }
 
 def keyfire() {
-  if ("${device.currentValue("key")}" == 'key') {
-    parent.sendUrl('panic?type=1')
-  }
+	if ("${device.currentValue("key")}" == 'key') {
+		parent.sendUrl('panic?type=1')
+	}
 }
 
 def keyaux() {
-  if ("${device.currentValue("key")}" == 'key') {
-    parent.sendUrl('panic?type=2')
-  }
+	if ("${device.currentValue("key")}" == 'key') {
+		parent.sendUrl('panic?type=2')
+	}
 }
 
 def keypanic() {
-  if ("${device.currentValue("key")}" == 'key') {
-    parent.sendUrl('panic?type=3')
-  }
+	if ("${device.currentValue("key")}" == 'key') {
+		parent.sendUrl('panic?type=3')
+	}
 }
 
 def refresh() {
-  parent.sendUrl('refresh')
+	parent.sendUrl('refresh')
 }
 
 def reset() {
-  parent.sendUrl('reset')
+	parent.sendUrl('reset')
 }
 
 def stay() {
-  parent.sendUrl('stayarm')
+	parent.sendUrl('stayarm')
 }
 
 def togglechime() {
-  parent.sendUrl('togglechime')
+	parent.sendUrl('togglechime')
 }

--- a/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
+++ b/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
@@ -30,11 +30,12 @@ metadata {
         command "togglechime"
     }
 
-    // simulator metadata
-    simulator {
-    }
+	// simulator metadata
+	simulator {
+    	
+	}
 
-// UI tile definitions
+	// UI tile definitions
 	tiles(scale: 2) {
 		multiAttributeTile(name:"status", type: "general", width: 6, height: 4){
 			tileAttribute ("device.status", key: "PRIMARY_CONTROL") {

--- a/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
+++ b/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
@@ -53,8 +53,8 @@ metadata {
 			}
 		}
         
-        // This title is just a hidden title for use in the "Things" lists
-        standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
+        	// This title is just a hidden title for use in the "Things" lists
+        	standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
 			state "alarm", label:'Alarming', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
 			state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
 			state "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"

--- a/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
+++ b/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
@@ -56,17 +56,17 @@ metadata {
         // This title is just a hidden title for use in the "Things" lists
         standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
 			state "alarm", label:'Alarming', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
-        	state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
-        	state "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        	state "duress", label:'Duress', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
-        	state "entrydelay", label:'Entry Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-        	state "exitdelay", label:'Exit Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-        	state "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
-        	state "ready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        	state "forceready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        	state "stay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
-        	state "instantaway", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
-        	state "instantstay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+			state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+			state "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+			state "duress", label:'Duress', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+			state "entrydelay", label:'Entry Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+			state "exitdelay", label:'Exit Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+			state "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
+			state "ready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+			state "forceready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+			state "stay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+			state "instantaway", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+			state "instantstay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
 		}
 		standardTile("away", "capability.momentary", width: 2, height: 2, title: "Away", decoration: "flat"){
 			state "away", label: 'Away', action: "away", icon: "st.presence.car.car", backgroundColor: "#6666FF"
@@ -90,56 +90,56 @@ metadata {
 			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
 		}
 		//standardTile("instant", "capability.momentary", width: 2, height: 2, title: "Instant"){
-		//  state "instant", label: 'Instant', action: "instant", icon: "st.locks.lock.locked", backgroundColor: "#00FF00"
+			//state "instant", label: 'Instant', action: "instant", icon: "st.locks.lock.locked", backgroundColor: "#00FF00"
 		//}
 		//standardTile("night", "capability.momentary", width: 2, height: 2, title: "Night"){
-		//  state "night", label: 'Night', action: "night", icon: "st.Bedroom.bedroom2", backgroundColor: "#AA00FF"
+			//state "night", label: 'Night', action: "night", icon: "st.Bedroom.bedroom2", backgroundColor: "#AA00FF"
 		//}
 		//standardTile("reset", "capability.momentary", width: 2, height: 2, title: "Sensor Reset"){
-		//  state "reset", label: 'Sensor\u00A0Reset', action: "reset", icon: "st.alarm.smoke.smoke", backgroundColor: "#FF3000"
+			//state "reset", label: 'Sensor\u00A0Reset', action: "reset", icon: "st.alarm.smoke.smoke", backgroundColor: "#FF3000"
 		//}
 		//standardTile("bypassoff", "capability.momentary", width: 2, height: 2, title: "Bypass Off"){
-		//  state "bypassoff", label: 'Bypass\u00A0Off', action: "bypassoff", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
+			//state "bypassoff", label: 'Bypass\u00A0Off', action: "bypassoff", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
 		//}
 		//valueTile("ledready", "device.ledready", width: 2, height: 1){
-		//  state "ledready", label:'Ready: ${currentValue}'
+			//state "ledready", label:'Ready: ${currentValue}'
 		//}
 		//valueTile("ledarmed", "device.ledarmed", width: 2, height: 1){
-		//  state "ledarmed", label:'Armed: ${currentValue}'
+			//state "ledarmed", label:'Armed: ${currentValue}'
 		//}
 		//valueTile("ledmemory", "device.ledmemory", width: 2, height: 1){
-		//  state "ledmemory", label:'Memory: ${currentValue}'
+			//state "ledmemory", label:'Memory: ${currentValue}'
 		//}
 		//valueTile("ledbypass", "device.ledbypass", width: 2, height: 1){
-		//  state "ledbypass", label:'Bypass: ${currentValue}'
+			//state "ledbypass", label:'Bypass: ${currentValue}'
 		//}
 		//valueTile("ledtrouble", "device.ledtrouble", width: 2, height: 1){
-		//  state "ledtrouble", label:'Trouble: ${currentValue}'
+			//state "ledtrouble", label:'Trouble: ${currentValue}'
 		//}
 		//valueTile("ledprogram", "device.ledprogram", width: 2, height: 1){
-		//  state "ledprogram", label:'Program: ${currentValue}'
+			//state "ledprogram", label:'Program: ${currentValue}'
 		//}
 		//valueTile("ledfire", "device.ledfire", width: 2, height: 1){
-		//  state "ledfire", label:'Fire: ${currentValue}'
+			//state "ledfire", label:'Fire: ${currentValue}'
 		//}
 		//valueTile("ledbacklight", "device.ledbacklight", width: 2, height: 1){
-		//  state "ledbacklight", label:'Backlight: ${currentValue}'
+			//state "ledbacklight", label:'Backlight: ${currentValue}'
 		//}
 		//standardTile("key", "device.key", width: 2, height: 2, title: "Key"){
-		//  state "nokey", label: 'Alarm\u00A0Keys\u00A0Off', action: "key", icon: "st.illuminance.illuminance.dark", backgroundColor: "#7B3516", defaultState: true
-		//  state "key", label: 'Alarm\u00A0Keys\u00A0On', action: "nokey", icon: "st.illuminance.illuminance.light", backgroundColor: "#FF6E2E"
+			//state "nokey", label: 'Alarm\u00A0Keys\u00A0Off', action: "key", icon: "st.illuminance.illuminance.dark", backgroundColor: "#7B3516", defaultState: true
+			//state "key", label: 'Alarm\u00A0Keys\u00A0On', action: "nokey", icon: "st.illuminance.illuminance.light", backgroundColor: "#FF6E2E"
 		//}
 		//standardTile("keyfire", "device.keyfire", width: 2, height: 2, title: "Fire Key"){
-		//  state "restore", label: 'Fire\u00A0Key', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
-		//  state "alarm", label: 'Fire\u00A0Key\u00A0Alarm', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
+			//state "restore", label: 'Fire\u00A0Key', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
+			//state "alarm", label: 'Fire\u00A0Key\u00A0Alarm', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
 		//}
 		//standardTile("keyaux", "device.keyaux", width: 2, height: 2, title: "Aux Key"){
-		//  state "restore", label: 'Aux\u00A0Key', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
-		//  state "alarm", label: 'Aux\u00A0Key\u00A0Alarm', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
+			//state "restore", label: 'Aux\u00A0Key', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
+			//state "alarm", label: 'Aux\u00A0Key\u00A0Alarm', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
 		//}
 		//standardTile("keypanic", "device.keypanic", width: 2, height: 2, title: "Panic Key"){
-		//  state "restore", label: 'Panic\u00A0Key', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
-		//  state "alarm", label: 'Panic\u00A0Key\u00A0Alarm', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
+			//state "restore", label: 'Panic\u00A0Key', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
+			//state "alarm", label: 'Panic\u00A0Key\u00A0Alarm', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
 		//}
 
 		main "statusHidden"

--- a/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
+++ b/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
@@ -9,7 +9,7 @@
 
 metadata {
     // Automatically generated. Make future change here.
-    definition (name: "DSC Stay Panel", author: "Jordan <jordan@xeron.cc>", namespace: 'dsc') {
+    definition (name: "DSC Stay Panel", author: "Jordan <jordan@xeron.cc>", namespace: 'DSC') {
         capability "Switch"
         capability "Refresh"
 
@@ -33,99 +33,116 @@ metadata {
     simulator {
     }
 
-    // UI tile definitions
-    tiles(scale: 2) {
-      standardTile ("status", "device.status", width: 4, height: 4, title: "Status") {
-        state "alarm", label:'Alarm', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
-        state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#800000"
-        state "disarm", label:'Disarmed', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        state "duress", label:'Duress', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
-        state "entrydelay", label:'Entry Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-        state "exitdelay", label:'Exit Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
-        state "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
-        state "ready", label:'Ready', action: 'stay', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        state "forceready", label:'Ready - F', action: 'stay', icon:"st.security.alarm.off", backgroundColor:"#79b821"
-        state "stay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#008CC1"
-        state "instantaway", label:'Armed Instant Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#800000"
-        state "instantstay", label:'Armed Instant Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#008CC1"
-      }
-      standardTile("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-        state "detected", label: 'Trouble', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
-        state "clear", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear", backgroundColor: "#79b821"
-      }
-      standardTile("chime", "device.chime", width: 2, height: 2, title: "Chime"){
-        state "togglechime", label: 'Toggling\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep", backgroundColor: "#fbd48a"
-        state "chime", label: 'Chime', action: "togglechime", icon: "st.alarm.beep.beep", backgroundColor: "#EE9D00"
-        state "nochime", label: 'No\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep", backgroundColor: "#796338"
-      }
-      standardTile("disarm", "capability.momentary", width: 2, height: 2, title: "Disarm"){
-        state "disarm", label: 'Disarm', action: "disarm", icon: "st.presence.house.unlocked", backgroundColor: "#79b821"
-      }
-      standardTile("away", "capability.momentary", width: 2, height: 2, title: "Away"){
-        state "away", label: 'Away', action: "away", icon: "st.presence.car.car", backgroundColor: "#800000"
-      }
-      standardTile("stay", "capability.momentary", width: 2, height: 2, title: "Stay"){
-        state "stay", label: 'Stay', action: "stay", icon: "st.presence.house.secured", backgroundColor: "#008CC1"
-      }
-      standardTile("instant", "capability.momentary", width: 2, height: 2, title: "Instant"){
-        state "instant", label: 'Instant', action: "instant", icon: "st.locks.lock.locked", backgroundColor: "#00FF00"
-      }
-      standardTile("night", "capability.momentary", width: 2, height: 2, title: "Night"){
-        state "night", label: 'Night', action: "night", icon: "st.Bedroom.bedroom2", backgroundColor: "#AA00FF"
-      }
-      standardTile("reset", "capability.momentary", width: 2, height: 2, title: "Sensor Reset"){
-        state "reset", label: 'Sensor\u00A0Reset', action: "reset", icon: "st.alarm.smoke.smoke", backgroundColor: "#FF3000"
-      }
-      standardTile("bypassoff", "capability.momentary", width: 2, height: 2, title: "Bypass Off"){
-        state "bypassoff", label: 'Bypass\u00A0Off', action: "bypassoff", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
-      }
-      valueTile("ledready", "device.ledready", width: 2, height: 1){
-        state "ledready", label:'Ready: ${currentValue}'
-      }
-      valueTile("ledarmed", "device.ledarmed", width: 2, height: 1){
-        state "ledarmed", label:'Armed: ${currentValue}'
-      }
-      valueTile("ledmemory", "device.ledmemory", width: 2, height: 1){
-        state "ledmemory", label:'Memory: ${currentValue}'
-      }
-      valueTile("ledbypass", "device.ledbypass", width: 2, height: 1){
-        state "ledbypass", label:'Bypass: ${currentValue}'
-      }
-      valueTile("ledtrouble", "device.ledtrouble", width: 2, height: 1){
-        state "ledtrouble", label:'Trouble: ${currentValue}'
-      }
-      valueTile("ledprogram", "device.ledprogram", width: 2, height: 1){
-        state "ledprogram", label:'Program: ${currentValue}'
-      }
-      valueTile("ledfire", "device.ledfire", width: 2, height: 1){
-        state "ledfire", label:'Fire: ${currentValue}'
-      }
-      valueTile("ledbacklight", "device.ledbacklight", width: 2, height: 1){
-        state "ledbacklight", label:'Backlight: ${currentValue}'
-      }
-      standardTile("key", "device.key", width: 2, height: 2, title: "Key"){
-        state "nokey", label: 'Alarm\u00A0Keys\u00A0Off', action: "key", icon: "st.illuminance.illuminance.dark", backgroundColor: "#7B3516", defaultState: true
-        state "key", label: 'Alarm\u00A0Keys\u00A0On', action: "nokey", icon: "st.illuminance.illuminance.light", backgroundColor: "#FF6E2E"
-      }
-      standardTile("keyfire", "device.keyfire", width: 2, height: 2, title: "Fire Key"){
-        state "restore", label: 'Fire\u00A0Key', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
-        state "alarm", label: 'Fire\u00A0Key\u00A0Alarm', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
-      }
-      standardTile("keyaux", "device.keyaux", width: 2, height: 2, title: "Aux Key"){
-        state "restore", label: 'Aux\u00A0Key', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
-        state "alarm", label: 'Aux\u00A0Key\u00A0Alarm', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
-      }
-      standardTile("keypanic", "device.keypanic", width: 2, height: 2, title: "Panic Key"){
-        state "restore", label: 'Panic\u00A0Key', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
-        state "alarm", label: 'Panic\u00A0Key\u00A0Alarm', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
-      }
-      standardTile("refresh", "device.refresh", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-        state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
-      }
+// UI tile definitions
+	tiles(scale: 2) {
+		multiAttributeTile(name:"status", type: "general", width: 6, height: 4){
+			tileAttribute ("device.status", key: "PRIMARY_CONTROL") {
+				attributeState "alarm", label:'Alarming', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+				attributeState "away", label:'Armed Away', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+				attributeState "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+				attributeState "duress", label:'Duress', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+				attributeState "entrydelay", label:'Entry Delay', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+				attributeState "exitdelay", label:'Exit Delay', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+				attributeState "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
+				attributeState "ready", label:'Ready', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+				attributeState "forceready", label:'Ready', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+				attributeState "stay", label:'Armed Stay', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+				attributeState "instantaway", label:'Armed Away', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+				attributeState "instantstay", label:'Armed Stay', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+			}
+		}
+        
+        // This title is just a hidden title for use in the "Things" lists
+        standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
+			state "alarm", label:'Alarming', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+        	state "away", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+        	state "disarm", label:'Disarm', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+        	state "duress", label:'Duress', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"
+        	state "entrydelay", label:'Entry Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+        	state "exitdelay", label:'Exit Delay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#ff9900"
+        	state "notready", label:'Not Ready', icon:"st.security.alarm.off", backgroundColor:"#ffcc00"
+        	state "ready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+        	state "forceready", label:'Ready', action: 'away', icon:"st.security.alarm.off", backgroundColor:"#79b821"
+        	state "stay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+        	state "instantaway", label:'Armed Away', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#6666FF"
+        	state "instantstay", label:'Armed Stay', action: 'disarm', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
+		}
+		standardTile("away", "capability.momentary", width: 2, height: 2, title: "Away", decoration: "flat"){
+			state "away", label: 'Away', action: "away", icon: "st.presence.car.car", backgroundColor: "#6666FF"
+		}
+		standardTile("stay", "capability.momentary", width: 2, height: 2, title: "Stay", decoration: "flat"){
+			state "stay", label: 'Stay', action: "stay", icon: "st.presence.house.secured", backgroundColor: "#00A0DC"
+		}
+		standardTile("disarm", "capability.momentary", width: 2, height: 2, title: "Disarm", decoration: "flat"){
+			state "disarm", label: 'Disarm', action: "disarm", icon: "st.presence.house.unlocked", backgroundColor: "#79b821"
+		}
+		standardTile("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
+			state "detected", label: 'Trouble', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
+			state "clear", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear"
+		}
+		standardTile("chime", "device.chime", width: 2, height: 2, title: "Chime", decoration: "flat"){
+			state "togglechime", label: 'Toggling\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#fbd48a"
+			state "chime", label: 'Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#EE9D00"
+			state "nochime", label: 'No\u00A0Chime', action: "togglechime", icon: "st.alarm.beep.beep"//, backgroundColor: "#796338"
+		}
+		standardTile("refresh", "device.refresh", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
+			state "default", action:"refresh.refresh", icon:"st.secondary.refresh"
+		}
+		//standardTile("instant", "capability.momentary", width: 2, height: 2, title: "Instant"){
+		//  state "instant", label: 'Instant', action: "instant", icon: "st.locks.lock.locked", backgroundColor: "#00FF00"
+		//}
+		//standardTile("night", "capability.momentary", width: 2, height: 2, title: "Night"){
+		//  state "night", label: 'Night', action: "night", icon: "st.Bedroom.bedroom2", backgroundColor: "#AA00FF"
+		//}
+		//standardTile("reset", "capability.momentary", width: 2, height: 2, title: "Sensor Reset"){
+		//  state "reset", label: 'Sensor\u00A0Reset', action: "reset", icon: "st.alarm.smoke.smoke", backgroundColor: "#FF3000"
+		//}
+		//standardTile("bypassoff", "capability.momentary", width: 2, height: 2, title: "Bypass Off"){
+		//  state "bypassoff", label: 'Bypass\u00A0Off', action: "bypassoff", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
+		//}
+		//valueTile("ledready", "device.ledready", width: 2, height: 1){
+		//  state "ledready", label:'Ready: ${currentValue}'
+		//}
+		//valueTile("ledarmed", "device.ledarmed", width: 2, height: 1){
+		//  state "ledarmed", label:'Armed: ${currentValue}'
+		//}
+		//valueTile("ledmemory", "device.ledmemory", width: 2, height: 1){
+		//  state "ledmemory", label:'Memory: ${currentValue}'
+		//}
+		//valueTile("ledbypass", "device.ledbypass", width: 2, height: 1){
+		//  state "ledbypass", label:'Bypass: ${currentValue}'
+		//}
+		//valueTile("ledtrouble", "device.ledtrouble", width: 2, height: 1){
+		//  state "ledtrouble", label:'Trouble: ${currentValue}'
+		//}
+		//valueTile("ledprogram", "device.ledprogram", width: 2, height: 1){
+		//  state "ledprogram", label:'Program: ${currentValue}'
+		//}
+		//valueTile("ledfire", "device.ledfire", width: 2, height: 1){
+		//  state "ledfire", label:'Fire: ${currentValue}'
+		//}
+		//valueTile("ledbacklight", "device.ledbacklight", width: 2, height: 1){
+		//  state "ledbacklight", label:'Backlight: ${currentValue}'
+		//}
+		//standardTile("key", "device.key", width: 2, height: 2, title: "Key"){
+		//  state "nokey", label: 'Alarm\u00A0Keys\u00A0Off', action: "key", icon: "st.illuminance.illuminance.dark", backgroundColor: "#7B3516", defaultState: true
+		//  state "key", label: 'Alarm\u00A0Keys\u00A0On', action: "nokey", icon: "st.illuminance.illuminance.light", backgroundColor: "#FF6E2E"
+		//}
+		//standardTile("keyfire", "device.keyfire", width: 2, height: 2, title: "Fire Key"){
+		//  state "restore", label: 'Fire\u00A0Key', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
+		//  state "alarm", label: 'Fire\u00A0Key\u00A0Alarm', action: "keyfire", icon: "st.Home.home29", backgroundColor: "#FF2400"
+		//}
+		//standardTile("keyaux", "device.keyaux", width: 2, height: 2, title: "Aux Key"){
+		//  state "restore", label: 'Aux\u00A0Key', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
+		//  state "alarm", label: 'Aux\u00A0Key\u00A0Alarm', action: "keyaux", icon: "st.Transportation.transportation7", backgroundColor: "#DD0000"
+		//}
+		//standardTile("keypanic", "device.keypanic", width: 2, height: 2, title: "Panic Key"){
+		//  state "restore", label: 'Panic\u00A0Key', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
+		//  state "alarm", label: 'Panic\u00A0Key\u00A0Alarm', action: "keypanic", icon: "st.Transportation.transportation9", backgroundColor: "#000fd5"
+		//}
 
-
-      main "status"
-      details(["status", "trouble", "chime", "away", "stay", "disarm", "instant", "night", "reset", "bypassoff", "ledready", "ledarmed", "ledmemory", "ledbypass", "key", "ledtrouble", "ledprogram", "ledfire", "ledbacklight", "keyfire", "keyaux", "keypanic", "refresh"])
+		main "statusHidden"
+		details(["status", "away", "stay", "disarm", "trouble", "chime", "refresh"])
     }
 }
 

--- a/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
+++ b/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
@@ -9,26 +9,26 @@
  // for the UI
 
 metadata {
-    // Automatically generated. Make future change here.
-    definition (name: "DSC Stay Panel", author: "Jordan <jordan@xeron.cc>", namespace: 'DSC') {
-        capability "Switch"
-        capability "Refresh"
+	// Automatically generated. Make future change here.
+	definition (name: "DSC Stay Panel", author: "Jordan <jordan@xeron.cc>", namespace: 'DSC') {
+		capability "Switch"
+		capability "Refresh"
 
-        command "away"
-        command "bypassoff"
-        command "disarm"
-        command "instant"
-        command "night"
-        command "nokey"
-        command "partition"
-        command "key"
-        command "keyfire"
-        command "keyaux"
-        command "keypanic"
-        command "reset"
-        command "stay"
-        command "togglechime"
-    }
+		command "away"
+		command "bypassoff"
+		command "disarm"
+		command "instant"
+		command "night"
+		command "nokey"
+		command "partition"
+		command "key"
+		command "keyfire"
+		command "keyaux"
+		command "keypanic"
+		command "reset"
+		command "stay"
+		command "togglechime"
+	}
 
 	// simulator metadata
 	simulator {

--- a/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
+++ b/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
@@ -53,7 +53,6 @@ metadata {
 				attributeState "instantstay", label:'Armed Stay', icon:"st.security.alarm.on", backgroundColor:"#00A0DC"
 			}
 		}
-        
         	// This title is just a hidden title for use in the "Things" lists
         	standardTile ("statusHidden", "device.status", width: 4, height: 4, title: "Status") {
 			state "alarm", label:'Alarming', action: 'disarm', icon:"st.security.alarm.alarm", backgroundColor:"#ff0000"

--- a/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
+++ b/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
@@ -4,6 +4,7 @@
  *  Author: Jordan <jordan@xeron.cc
  *  Original Code By: Rob Fisher <robfish@att.net>, Carlos Santiago <carloss66@gmail.com>, JTT <aesystems@gmail.com>
  *  Date: 2016-02-03
+ *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
  // for the UI
 

--- a/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
+++ b/devicetypes/dsc/dsc-stay-panel.src/dsc-stay-panel.groovy
@@ -144,7 +144,7 @@ metadata {
 
 		main "statusHidden"
 		details(["status", "away", "stay", "disarm", "trouble", "chime", "refresh"])
-    }
+	}
 }
 
 def partition(String state, String partition, Map parameters) {

--- a/devicetypes/dsc/dsc-zone-co.src/dsc-zone-co.groovy
+++ b/devicetypes/dsc/dsc-zone-co.src/dsc-zone-co.groovy
@@ -5,11 +5,12 @@
  *  Originally by: Matt Martz <matt.martz@gmail.com>
  *  Modified by: Kent Holloway <drizit@gmail.com>
  *  Date: 2016-02-27
+ *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone CO", author: "jordan@xeron.cc", namespace: 'dsc') {
+  definition (name: "DSC Zone CO", author: "jordan@xeron.cc", namespace: 'DSC') {
     // Change or define capabilities here as needed
     capability "Carbon Monoxide Detector"
     capability "Sensor"
@@ -25,25 +26,29 @@ metadata {
   }
 
   tiles(scale: 2) {
-    standardTile ("zone", "device.carbonMonoxide", width: 4, height: 4, title: "Zone") {
-      state "clear",  label: 'clear',  icon: "st.alarm.carbon-monoxide.clear", backgroundColor: "#ffffff"
-      state "detected",  label: 'SMOKE',  icon: "st.alarm.carbon-monoxide.carbon-monoxide", backgroundColor: "#e86d13"
-      state "tested", label: 'TESTED', icon: "st.alarm.carbon-monoxide.test",  backgroundColor: "#e86d13"
+  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+        tileAttribute ("device.carbonMonoxide", key: "PRIMARY_CONTROL") {
+            attributeState "clear", label:'Clear', icon:"st.alarm.carbon-monoxide.clear", backgroundColor:"#ffffff"
+            attributeState "detected", label:'Smoke', icon:"st.alarm.carbon-monoxide.carbon-monoxide", backgroundColor:"#e86d13"
+            attributeState "tested", label:'Tested', icon:"st.alarm.carbon-monoxide.test", backgroundColor:"#e86d13"
+        }
     }
     standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-      state "restore", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear", backgroundColor: "#79b821"
+      state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
       state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
       state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
     }
-    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass"){
-      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
+    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
+      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
     }
-
+	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+	}
+    
     // This tile will be the tile that is displayed on the Hub page.
     main "zone"
 
     // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "trouble", "bypass"])
+    details(["zone", "spacerTile","trouble", "bypass", "spacerTile"])
   }
 }
 

--- a/devicetypes/dsc/dsc-zone-co.src/dsc-zone-co.groovy
+++ b/devicetypes/dsc/dsc-zone-co.src/dsc-zone-co.groovy
@@ -10,78 +10,79 @@
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone CO", author: "jordan@xeron.cc", namespace: 'DSC') {
-    // Change or define capabilities here as needed
-    capability "Carbon Monoxide Detector"
-    capability "Sensor"
-    capability "Momentary"
+	definition (name: "DSC Zone CO", author: "jordan@xeron.cc", namespace: 'DSC') {
+		// Change or define capabilities here as needed
+		capability "Carbon Monoxide Detector"
+		capability "Sensor"
+		capability "Momentary"
 
-    // Add commands as needed
-    command "zone"
-    command "bypass"
-  }
-
-  simulator {
-    // Nothing here, you could put some testing stuff here if you like
-  }
-
-  tiles(scale: 2) {
-  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
-        tileAttribute ("device.carbonMonoxide", key: "PRIMARY_CONTROL") {
-            attributeState "clear", label:'Clear', icon:"st.alarm.carbon-monoxide.clear", backgroundColor:"#ffffff"
-            attributeState "detected", label:'Smoke', icon:"st.alarm.carbon-monoxide.carbon-monoxide", backgroundColor:"#e86d13"
-            attributeState "tested", label:'Tested', icon:"st.alarm.carbon-monoxide.test", backgroundColor:"#e86d13"
-        }
-    }
-    standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-      state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
-      state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
-      state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
-    }
-    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
-      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
-    }
-	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+		// Add commands as needed
+		command "zone"
+		command "bypass"
 	}
-    
-    // This tile will be the tile that is displayed on the Hub page.
-    main "zone"
 
-    // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "spacerTile","trouble", "bypass", "spacerTile"])
-  }
+	simulator {
+		// Nothing here, you could put some testing stuff here if you like
+	}
+
+	tiles(scale: 2) {
+		multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+			tileAttribute ("device.carbonMonoxide", key: "PRIMARY_CONTROL") {
+				attributeState "clear", label:'Clear', icon:"st.alarm.carbon-monoxide.clear", backgroundColor:"#ffffff"
+				attributeState "detected", label:'Smoke', icon:"st.alarm.carbon-monoxide.carbon-monoxide", backgroundColor:"#e86d13"
+				attributeState "tested", label:'Tested', icon:"st.alarm.carbon-monoxide.test", backgroundColor:"#e86d13"
+        		}
+    		}
+		standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
+			state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
+			state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
+			state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
+		}
+		standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
+			state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
+		}
+		standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+		}
+
+		// This tile will be the tile that is displayed on the Hub page.
+		main "zone"
+
+		// These tiles will be displayed when clicked on the device, in the order listed here.
+		details(["zone", "spacerTile","trouble", "bypass", "spacerTile"])
+	}
 }
 
 // handle commands
 def bypass() {
-  def zone = device.deviceNetworkId.minus('dsczone')
-  parent.sendUrl("bypass?zone=${zone}")  
+	def zone = device.deviceNetworkId.minus('dsczone')
+	parent.sendUrl("bypass?zone=${zone}")  
 }
 
 def push() {
-  bypass()
+	bypass()
 }
 
 def zone(String state) {
-  // state will be a valid state for a zone (open, closed)
-  // zone will be a number for the zone
-  log.debug "Zone: ${state}"
+	// state will be a valid state for a zone (open, closed)
+	// zone will be a number for the zone
+	log.debug "Zone: ${state}"
 
-  def troubleList = ['fault','tamper','restore']
+	def troubleList = ['fault','tamper','restore']
 
-  if (troubleList.contains(state)) {
-    // Send final event
-    sendEvent (name: "trouble", value: "${state}")
-  } else {
-    // Since this is a carbonMonoxide device we need to convert the values to match the device capabilities
-    // before sending the event
-    def eventMap = [
-     'open':"tested",
-     'closed':"clear",
-     'alarm':"detected"
-    ]
-    def newState = eventMap."${state}"
-    // Send final event
-    sendEvent (name: "carbonMonoxide", value: "${newState}")
-  }
+	if (troubleList.contains(state)) {
+		// Send final event
+		sendEvent (name: "trouble", value: "${state}")
+	} 
+	else {
+		// Since this is a carbonMonoxide device we need to convert the values to match the device capabilities
+		// before sending the event
+		def eventMap = [
+			'open':"tested",
+			'closed':"clear",
+			'alarm':"detected"
+		]
+		def newState = eventMap."${state}"
+		// Send final event
+		sendEvent (name: "carbonMonoxide", value: "${newState}")
+	}
 }

--- a/devicetypes/dsc/dsc-zone-contact.src/dsc-zone-contact.groovy
+++ b/devicetypes/dsc/dsc-zone-contact.src/dsc-zone-contact.groovy
@@ -4,11 +4,12 @@
  *  Author: Jordan <jordan@xeron.cc>
  *  Original Author: Matt Martz <matt.martz@gmail.com>
  *  Date: 2016-02-27
+ *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Contact", author: "jordan@xeron.cc", namespace: 'dsc') {
+  definition (name: "DSC Zone Contact", author: "jordan@xeron.cc", namespace: 'DSC') {
     // Change or define capabilities here as needed
     capability "Contact Sensor"
     capability "Sensor"
@@ -24,25 +25,29 @@ metadata {
   }
 
   tiles(scale: 2) {
-    standardTile ("zone", "device.contact", width: 4, height: 4, title: "Zone") {
-      state "open",   label: '${name}', icon: "st.contact.contact.open",   backgroundColor: "#ffa81e"
-      state "closed", label: '${name}', icon: "st.contact.contact.closed", backgroundColor: "#79b821"
-      state "alarm",  label: '${name}', icon: "st.contact.contact.open",   backgroundColor: "#ff0000"
-     }
-     standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-       state "restore", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear", backgroundColor: "#79b821"
+  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+        tileAttribute ("device.contact", key: "PRIMARY_CONTROL") {
+            attributeState "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
+            attributeState "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
+            attributeState "alarm", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ff0000"
+        }
+    }
+	standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
+       state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
        state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
        state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
-     }
-     standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass"){
-       state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
-     }
-
+	}
+	standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
+       state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
+	}
+    standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+	}
+    
     // This tile will be the tile that is displayed on the Hub page.
     main "zone"
 
     // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "trouble", "bypass"])
+    details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
   }
 }
 

--- a/devicetypes/dsc/dsc-zone-contact.src/dsc-zone-contact.groovy
+++ b/devicetypes/dsc/dsc-zone-contact.src/dsc-zone-contact.groovy
@@ -9,69 +9,70 @@
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Contact", author: "jordan@xeron.cc", namespace: 'DSC') {
-    // Change or define capabilities here as needed
-    capability "Contact Sensor"
-    capability "Sensor"
-    capability "Momentary"
+	definition (name: "DSC Zone Contact", author: "jordan@xeron.cc", namespace: 'DSC') {
+		// Change or define capabilities here as needed
+		capability "Contact Sensor"
+		capability "Sensor"
+		capability "Momentary"
 
-    // Add commands as needed
-    command "zone"
-    command "bypass"
-  }
+		// Add commands as needed
+		command "zone"
+		command "bypass"
+	}
 
-  simulator {
-    // Nothing here, you could put some testing stuff here if you like
-  }
+	simulator {
+		// Nothing here, you could put some testing stuff here if you like
+	}
 
-  tiles(scale: 2) {
-  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
-        tileAttribute ("device.contact", key: "PRIMARY_CONTROL") {
-            attributeState "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
-            attributeState "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
-            attributeState "alarm", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ff0000"
-        }
-    }
-	standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-       state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
-       state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
-       state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
-	}
-	standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
-       state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
-	}
-    standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
-	}
+	tiles(scale: 2) {
+		multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+			tileAttribute ("device.contact", key: "PRIMARY_CONTROL") {
+				attributeState "open", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ffa81e"
+				attributeState "closed", label:'${name}', icon:"st.contact.contact.closed", backgroundColor:"#79b821"
+				attributeState "alarm", label:'${name}', icon:"st.contact.contact.open", backgroundColor:"#ff0000"
+			}
+		}
+		standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
+			state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
+			state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
+			state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
+		}
+		standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
+			state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
+		}
+		standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+		}
     
-    // This tile will be the tile that is displayed on the Hub page.
-    main "zone"
+		// This tile will be the tile that is displayed on the Hub page.
+		main "zone"
 
-    // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
-  }
+		// These tiles will be displayed when clicked on the device, in the order listed here.
+		details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
+	}
 }
 
 // handle commands
 def bypass() {
-  def zone = device.deviceNetworkId.minus('dsczone')
-  parent.sendUrl("bypass?zone=${zone}")  
+	def zone = device.deviceNetworkId.minus('dsczone')
+	parent.sendUrl("bypass?zone=${zone}")  
 }
 
 def push() {
-  bypass()
+	bypass()
 }
 
 def zone(String state) {
-  // state will be a valid state for a zone (open, closed)
-  // zone will be a number for the zone
-  log.debug "Zone: ${state}"
+	// state will be a valid state for a zone (open, closed)
+	// zone will be a number for the zone
+	log.debug "Zone: ${state}"
 
-  def troubleList = ['fault','tamper','restore']
+	def troubleList = ['fault','tamper','restore']
 
-  if (troubleList.contains(state)) {
-    // Send final event
-    sendEvent (name: "trouble", value: "${state}")
-  } else {
-    sendEvent (name: "contact", value: "${state}")
-  }
+	if (troubleList.contains(state)) {
+		// Send final event
+		sendEvent (name: "trouble", value: "${state}")
+	} 
+	else {
+		sendEvent (name: "contact", value: "${state}")
+	}
 }

--- a/devicetypes/dsc/dsc-zone-flood.src/dsc-zone-flood.src
+++ b/devicetypes/dsc/dsc-zone-flood.src/dsc-zone-flood.src
@@ -1,0 +1,88 @@
+/*
+ *  DSC Zone Motion Device
+ *
+ *  Author: Jordan <jordan@xeron.cc>
+ *  Original Author: Matt Martz <matt.martz@gmail.com>
+ *  Modified to be a flood device: Mike Maat <mmaat@ualberta.ca>
+ *  Date: 2016-02-27
+ *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
+ */
+
+// for the UI
+metadata {
+  definition (name: "DSC Zone Flood", author: "jordan@xeron.cc/mmaat@ualberta.ca", namespace: 'DSC') {
+    // Change or define capabilities here as needed
+    capability "Water Sensor"
+    capability "Sensor"
+    capability "Momentary"
+
+    // Add commands as needed
+    command "zone"
+    command "bypass"
+  }
+
+  simulator {
+    // Nothing here, you could put some testing stuff here if you like
+  }
+
+  tiles(scale: 2) {
+  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+        tileAttribute ("device.motion", key: "PRIMARY_CONTROL") {
+        	attributeState "open", label:'Dry', icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
+            attributeState "closed", label:'Flood', icon:"st.alarm.water.wet", backgroundColor:"#ff0000"
+            attributeState "alarm", label:'Flood', icon:"st.alarm.water.wet", backgroundColor:"#ff0000"
+        }
+    }
+    standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
+      state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
+      state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
+      state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
+    }
+    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
+      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
+    }
+
+	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+	}
+    
+    // This tile will be the tile that is displayed on the Hub page.
+    main "zone"
+
+    // These tiles will be displayed when clicked on the device, in the order listed here.
+    details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
+  }
+}
+
+// handle commands
+def bypass() {
+  def zone = device.deviceNetworkId.minus('dsczone')
+  parent.sendUrl("bypass?zone=${zone}")  
+}
+
+def push() {
+  bypass()
+}
+
+def zone(String state) {
+  // state will be a valid state for a zone (open, closed)
+  // zone will be a number for the zone
+  log.debug "Zone: ${state}"
+
+  def troubleList = ['fault','tamper','restore']
+
+  if (troubleList.contains(state)) {
+    // Send final event
+    sendEvent (name: "trouble", value: "${state}")
+  } else {
+    // Since this is a motion sensor device we need to convert open to active and closed to inactive
+    // before sending the event
+    def eventMap = [
+     'open':"dry",
+     'closed':"wet",
+     'alarm':"wet"
+    ]
+    def newState = eventMap."${state}"
+    // Send final event
+    sendEvent (name: "water", value: "${newState}")
+  }
+}

--- a/devicetypes/dsc/dsc-zone-flood.src/dsc-zone-flood.src
+++ b/devicetypes/dsc/dsc-zone-flood.src/dsc-zone-flood.src
@@ -1,11 +1,9 @@
 /*
  *  DSC Zone Motion Device
  *
- *  Author: Jordan <jordan@xeron.cc>
- *  Original Author: Matt Martz <matt.martz@gmail.com>
- *  Modified to be a flood device: Mike Maat <mmaat@ualberta.ca>
- *  Date: 2016-02-27
- *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
+ *  Author: Mike Maat <mmaat@ualberta.ca>
+ *  Adapted From Original DSC Device Type Authors: Jordan <jordan@xeron.cc>, Matt Martz <matt.martz@gmail.com>
+ *  Date: 2016-04-08
  */
 
 // for the UI

--- a/devicetypes/dsc/dsc-zone-flood.src/dsc-zone-flood.src
+++ b/devicetypes/dsc/dsc-zone-flood.src/dsc-zone-flood.src
@@ -10,79 +10,79 @@
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Flood", author: "jordan@xeron.cc/mmaat@ualberta.ca", namespace: 'DSC') {
-    // Change or define capabilities here as needed
-    capability "Water Sensor"
-    capability "Sensor"
-    capability "Momentary"
+	definition (name: "DSC Zone Flood", author: "jordan@xeron.cc/mmaat@ualberta.ca", namespace: 'DSC') {
+		// Change or define capabilities here as needed
+		capability "Water Sensor"
+		capability "Sensor"
+		capability "Momentary"
 
-    // Add commands as needed
-    command "zone"
-    command "bypass"
-  }
-
-  simulator {
-    // Nothing here, you could put some testing stuff here if you like
-  }
-
-  tiles(scale: 2) {
-  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
-        tileAttribute ("device.motion", key: "PRIMARY_CONTROL") {
-        	attributeState "open", label:'Dry', icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
-            attributeState "closed", label:'Flood', icon:"st.alarm.water.wet", backgroundColor:"#ff0000"
-            attributeState "alarm", label:'Flood', icon:"st.alarm.water.wet", backgroundColor:"#ff0000"
-        }
-    }
-    standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-      state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
-      state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
-      state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
-    }
-    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
-      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
-    }
-
-	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+		// Add commands as needed
+		command "zone"
+		command "bypass"
 	}
-    
-    // This tile will be the tile that is displayed on the Hub page.
-    main "zone"
 
-    // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
-  }
+	simulator {
+		// Nothing here, you could put some testing stuff here if you like
+	}
+
+	tiles(scale: 2) {
+		multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+			tileAttribute ("device.motion", key: "PRIMARY_CONTROL") {
+				attributeState "open", label:'Dry', icon:"st.alarm.water.dry", backgroundColor:"#ffffff"
+				attributeState "closed", label:'Flood', icon:"st.alarm.water.wet", backgroundColor:"#ff0000"
+				attributeState "alarm", label:'Flood', icon:"st.alarm.water.wet", backgroundColor:"#ff0000"
+			}
+    		}
+		standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
+			state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
+			state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
+			state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
+		}
+		standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
+			state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
+		}
+		standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+		}
+    
+		// This tile will be the tile that is displayed on the Hub page.
+		main "zone"
+
+		// These tiles will be displayed when clicked on the device, in the order listed here.
+		details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
+	}
 }
 
 // handle commands
 def bypass() {
-  def zone = device.deviceNetworkId.minus('dsczone')
-  parent.sendUrl("bypass?zone=${zone}")  
+	def zone = device.deviceNetworkId.minus('dsczone')
+	parent.sendUrl("bypass?zone=${zone}")  
 }
 
 def push() {
-  bypass()
+	bypass()
 }
 
 def zone(String state) {
-  // state will be a valid state for a zone (open, closed)
-  // zone will be a number for the zone
-  log.debug "Zone: ${state}"
+	// state will be a valid state for a zone (open, closed)
+	// zone will be a number for the zone
+	log.debug "Zone: ${state}"
 
-  def troubleList = ['fault','tamper','restore']
+	def troubleList = ['fault','tamper','restore']
 
-  if (troubleList.contains(state)) {
-    // Send final event
-    sendEvent (name: "trouble", value: "${state}")
-  } else {
-    // Since this is a motion sensor device we need to convert open to active and closed to inactive
-    // before sending the event
-    def eventMap = [
-     'open':"dry",
-     'closed':"wet",
-     'alarm':"wet"
-    ]
-    def newState = eventMap."${state}"
-    // Send final event
-    sendEvent (name: "water", value: "${newState}")
-  }
+	if (troubleList.contains(state)) {
+		// Send final event
+		sendEvent (name: "trouble", value: "${state}")
+	} 
+	else {
+		// Since this is a motion sensor device we need to convert open to active and closed to inactive
+		// before sending the event
+		def eventMap = [
+			'open':"dry",
+			'closed':"wet",
+			'alarm':"wet"
+		]
+		def newState = eventMap."${state}"
+		// Send final event
+		sendEvent (name: "water", value: "${newState}")
+	}
 }

--- a/devicetypes/dsc/dsc-zone-motion.src/dsc-zone-motion.groovy
+++ b/devicetypes/dsc/dsc-zone-motion.src/dsc-zone-motion.groovy
@@ -1,18 +1,18 @@
 /*
- *  DSC Smoke Device (wireless & 4-wire zone-attached types only)
+ *  DSC Zone Motion Device
  *
  *  Author: Jordan <jordan@xeron.cc>
- *  Originally by: Matt Martz <matt.martz@gmail.com>
- *  Modified by: Kent Holloway <drizit@gmail.com>
+ *  Original Author: Matt Martz <matt.martz@gmail.com>
+ *  Modified to be a motion device: Kent Holloway <drizit@gmail.com>
  *  Date: 2016-02-27
  *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Smoke 4w", author: "jordan@xeron.cc", namespace: 'DSC') {
+  definition (name: "DSC Zone Motion", author: "jordan@xeron.cc", namespace: 'DSC') {
     // Change or define capabilities here as needed
-    capability "Smoke Detector"
+    capability "Motion Sensor"
     capability "Sensor"
     capability "Momentary"
 
@@ -27,10 +27,10 @@ metadata {
 
   tiles(scale: 2) {
   	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
-        tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
-            attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
-            attributeState "detected", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
-            attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
+        tileAttribute ("device.motion", key: "PRIMARY_CONTROL") {
+            attributeState "active", label:'Motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
+            attributeState "inactive", label:'No Motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
+            attributeState "alarm", label:'Alarm', icon:"st.motion.motion.active", backgroundColor:"#ff0000"
         }
     }
     standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
@@ -38,9 +38,10 @@ metadata {
       state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
       state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
     }
-    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass"){
-      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
+    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
+      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
     }
+
 	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
 	}
     
@@ -48,7 +49,7 @@ metadata {
     main "zone"
 
     // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "spacerTile","trouble", "bypass", "spacerTile"])
+    details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
   }
 }
 
@@ -73,15 +74,15 @@ def zone(String state) {
     // Send final event
     sendEvent (name: "trouble", value: "${state}")
   } else {
-    // Since this is a smoke device we need to convert the values to match the device capabilities
+    // Since this is a motion sensor device we need to convert open to active and closed to inactive
     // before sending the event
     def eventMap = [
-     'open':"tested",
-     'closed':"clear",
-     'alarm':"detected"
+     'open':"active",
+     'closed':"inactive",
+     'alarm':"alarm"
     ]
     def newState = eventMap."${state}"
     // Send final event
-    sendEvent (name: "smoke", value: "${newState}")
+    sendEvent (name: "motion", value: "${newState}")
   }
 }

--- a/devicetypes/dsc/dsc-zone-motion.src/dsc-zone-motion.groovy
+++ b/devicetypes/dsc/dsc-zone-motion.src/dsc-zone-motion.groovy
@@ -10,79 +10,80 @@
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Motion", author: "jordan@xeron.cc", namespace: 'DSC') {
-    // Change or define capabilities here as needed
-    capability "Motion Sensor"
-    capability "Sensor"
-    capability "Momentary"
+	definition (name: "DSC Zone Motion", author: "jordan@xeron.cc", namespace: 'DSC') {
+		// Change or define capabilities here as needed
+		capability "Motion Sensor"
+		capability "Sensor"
+		capability "Momentary"
 
-    // Add commands as needed
-    command "zone"
-    command "bypass"
-  }
-
-  simulator {
-    // Nothing here, you could put some testing stuff here if you like
-  }
-
-  tiles(scale: 2) {
-  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
-        tileAttribute ("device.motion", key: "PRIMARY_CONTROL") {
-            attributeState "active", label:'Motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
-            attributeState "inactive", label:'No Motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
-            attributeState "alarm", label:'Alarm', icon:"st.motion.motion.active", backgroundColor:"#ff0000"
-        }
-    }
-    standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-      state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
-      state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
-      state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
-    }
-    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
-      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
-    }
-
-	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+		// Add commands as needed
+		command "zone"
+		command "bypass"
 	}
-    
-    // This tile will be the tile that is displayed on the Hub page.
-    main "zone"
 
-    // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
-  }
+	simulator {
+		// Nothing here, you could put some testing stuff here if you like
+	}
+
+	tiles(scale: 2) {
+		multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+			tileAttribute ("device.motion", key: "PRIMARY_CONTROL") {
+				attributeState "active", label:'Motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
+				attributeState "inactive", label:'No Motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
+				attributeState "alarm", label:'Alarm', icon:"st.motion.motion.active", backgroundColor:"#ff0000"
+			}
+		}
+		standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
+			state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
+			state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
+			state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
+		}
+		standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
+			state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
+		}
+
+		standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+		}
+    
+		// This tile will be the tile that is displayed on the Hub page.
+		main "zone"
+
+		// These tiles will be displayed when clicked on the device, in the order listed here.
+		details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
+	}
 }
 
 // handle commands
 def bypass() {
-  def zone = device.deviceNetworkId.minus('dsczone')
-  parent.sendUrl("bypass?zone=${zone}")  
+	def zone = device.deviceNetworkId.minus('dsczone')
+	parent.sendUrl("bypass?zone=${zone}")  
 }
 
 def push() {
-  bypass()
+	bypass()
 }
 
 def zone(String state) {
-  // state will be a valid state for a zone (open, closed)
-  // zone will be a number for the zone
-  log.debug "Zone: ${state}"
+	// state will be a valid state for a zone (open, closed)
+	// zone will be a number for the zone
+	log.debug "Zone: ${state}"
 
-  def troubleList = ['fault','tamper','restore']
+	def troubleList = ['fault','tamper','restore']
 
-  if (troubleList.contains(state)) {
-    // Send final event
-    sendEvent (name: "trouble", value: "${state}")
-  } else {
-    // Since this is a motion sensor device we need to convert open to active and closed to inactive
-    // before sending the event
-    def eventMap = [
-     'open':"active",
-     'closed':"inactive",
-     'alarm':"alarm"
-    ]
-    def newState = eventMap."${state}"
-    // Send final event
-    sendEvent (name: "motion", value: "${newState}")
-  }
+	if (troubleList.contains(state)) {
+		// Send final event
+		sendEvent (name: "trouble", value: "${state}")
+	} 
+	else {
+		// Since this is a motion sensor device we need to convert open to active and closed to inactive
+		// before sending the event
+		def eventMap = [
+			'open':"active",
+			'closed':"inactive",
+			'alarm':"alarm"
+		]
+		def newState = eventMap."${state}"
+		// Send final event
+		sendEvent (name: "motion", value: "${newState}")
+	}
 }

--- a/devicetypes/dsc/dsc-zone-motion.src/dsc-zone-motion.groovy
+++ b/devicetypes/dsc/dsc-zone-motion.src/dsc-zone-motion.groovy
@@ -5,11 +5,12 @@
  *  Original Author: Matt Martz <matt.martz@gmail.com>
  *  Modified to be a motion device: Kent Holloway <drizit@gmail.com>
  *  Date: 2016-02-27
+ *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Motion", author: "jordan@xeron.cc", namespace: 'dsc') {
+  definition (name: "DSC Zone Motion", author: "jordan@xeron.cc", namespace: 'DSC') {
     // Change or define capabilities here as needed
     capability "Motion Sensor"
     capability "Sensor"
@@ -25,25 +26,30 @@ metadata {
   }
 
   tiles(scale: 2) {
-    standardTile ("zone", "device.motion", width: 4, height: 4, title: "Zone") {
-      state "active",   label:'motion',    icon:"st.motion.motion.active",   backgroundColor:"#53a7c0"
-      state "inactive", label:'no motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
-      state "alarm",    label:'ALARM',     icon:"st.motion.motion.active",   backgroundColor:"#ff0000"
+  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+        tileAttribute ("device.motion", key: "PRIMARY_CONTROL") {
+            attributeState "active", label:'Motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
+            attributeState "inactive", label:'No Motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
+            attributeState "alarm", label:'Alarm', icon:"st.motion.motion.active", backgroundColor:"#ff0000"
+        }
     }
     standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-      state "restore", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear", backgroundColor: "#79b821"
+      state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
       state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
       state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
     }
-    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass"){
-      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
+    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
+      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
     }
 
+	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+	}
+    
     // This tile will be the tile that is displayed on the Hub page.
     main "zone"
 
     // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "trouble", "bypass"])
+    details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
   }
 }
 

--- a/devicetypes/dsc/dsc-zone-motion.src/dsc-zone-motion.groovy
+++ b/devicetypes/dsc/dsc-zone-motion.src/dsc-zone-motion.groovy
@@ -1,18 +1,18 @@
 /*
- *  DSC Zone Motion Device
+ *  DSC Smoke Device (wireless & 4-wire zone-attached types only)
  *
  *  Author: Jordan <jordan@xeron.cc>
- *  Original Author: Matt Martz <matt.martz@gmail.com>
- *  Modified to be a motion device: Kent Holloway <drizit@gmail.com>
+ *  Originally by: Matt Martz <matt.martz@gmail.com>
+ *  Modified by: Kent Holloway <drizit@gmail.com>
  *  Date: 2016-02-27
  *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Motion", author: "jordan@xeron.cc", namespace: 'DSC') {
+  definition (name: "DSC Zone Smoke 4w", author: "jordan@xeron.cc", namespace: 'DSC') {
     // Change or define capabilities here as needed
-    capability "Motion Sensor"
+    capability "Smoke Detector"
     capability "Sensor"
     capability "Momentary"
 
@@ -27,10 +27,10 @@ metadata {
 
   tiles(scale: 2) {
   	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
-        tileAttribute ("device.motion", key: "PRIMARY_CONTROL") {
-            attributeState "active", label:'Motion', icon:"st.motion.motion.active", backgroundColor:"#53a7c0"
-            attributeState "inactive", label:'No Motion', icon:"st.motion.motion.inactive", backgroundColor:"#ffffff"
-            attributeState "alarm", label:'Alarm', icon:"st.motion.motion.active", backgroundColor:"#ff0000"
+        tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
+            attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
+            attributeState "detected", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
+            attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
         }
     }
     standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
@@ -38,10 +38,9 @@ metadata {
       state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
       state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
     }
-    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass", decoration: "flat"){
-      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked"
+    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass"){
+      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
     }
-
 	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
 	}
     
@@ -49,7 +48,7 @@ metadata {
     main "zone"
 
     // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "spacerTile", "trouble", "bypass", "spacerTile"])
+    details(["zone", "spacerTile","trouble", "bypass", "spacerTile"])
   }
 }
 
@@ -74,15 +73,15 @@ def zone(String state) {
     // Send final event
     sendEvent (name: "trouble", value: "${state}")
   } else {
-    // Since this is a motion sensor device we need to convert open to active and closed to inactive
+    // Since this is a smoke device we need to convert the values to match the device capabilities
     // before sending the event
     def eventMap = [
-     'open':"active",
-     'closed':"inactive",
-     'alarm':"alarm"
+     'open':"tested",
+     'closed':"clear",
+     'alarm':"detected"
     ]
     def newState = eventMap."${state}"
     // Send final event
-    sendEvent (name: "motion", value: "${newState}")
+    sendEvent (name: "smoke", value: "${newState}")
   }
 }

--- a/devicetypes/dsc/dsc-zone-smoke-2w.src/dsc-zone-smoke-2w.groovy
+++ b/devicetypes/dsc/dsc-zone-smoke-2w.src/dsc-zone-smoke-2w.groovy
@@ -24,11 +24,11 @@ metadata {
   tiles {
     // Main Row
     multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
-        tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
-            attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
-            attributeState "smoke", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
-            attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
-        }
+      tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
+        attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
+        attributeState "smoke", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
+        attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
+      }
     }
 
     // This tile will be the tile that is displayed on the Hub page.

--- a/devicetypes/dsc/dsc-zone-smoke-2w.src/dsc-zone-smoke-2w.groovy
+++ b/devicetypes/dsc/dsc-zone-smoke-2w.src/dsc-zone-smoke-2w.groovy
@@ -10,41 +10,41 @@
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Smoke 2w", author: "jordan@xeron.cc", namespace: 'DSC') {
-    // Change or define capabilities here as needed
-    capability "Smoke Detector"
-    capability "Sensor"
-    capability "Momentary"
+	definition (name: "DSC Zone Smoke 2w", author: "jordan@xeron.cc", namespace: 'DSC') {
+		// Change or define capabilities here as needed
+		capability "Smoke Detector"
+		capability "Sensor"
+		capability "Momentary"
 
-    // Add commands as needed
-    command "zone"
-    command "bypass"
-  }
+		// Add commands as needed
+		command "zone"
+		command "bypass"
+	}
 
-  tiles {
-    // Main Row
-    multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
-      tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
-        attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
-        attributeState "smoke", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
-        attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
-      }
-    }
+	tiles {
+		// Main Row
+		multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+			tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
+				attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
+				attributeState "smoke", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
+				attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
+			}
+		}
 
-    // This tile will be the tile that is displayed on the Hub page.
-    main "zone"
+		// This tile will be the tile that is displayed on the Hub page.
+		main "zone"
 
-    // These tiles will be displayed when clicked on the device, in the order listed here.
-    details "zone"
-  }
+		// These tiles will be displayed when clicked on the device, in the order listed here.
+		details "zone"
+	}
 }
 
 // handle commands
 def zone(String state) {
-  def text = null
-  def results = []
-  // state will be a valid state for a zone (open, closed)
-  // zone will be a number for the zone
-  log.debug "Zone: ${state}"
-  sendEvent (name: "smoke", value: "${state}")
+	def text = null
+	def results = []
+	// state will be a valid state for a zone (open, closed)
+	// zone will be a number for the zone
+	log.debug "Zone: ${state}"
+	sendEvent (name: "smoke", value: "${state}")
 }

--- a/devicetypes/dsc/dsc-zone-smoke-2w.src/dsc-zone-smoke-2w.groovy
+++ b/devicetypes/dsc/dsc-zone-smoke-2w.src/dsc-zone-smoke-2w.groovy
@@ -5,11 +5,12 @@
  *  Smoke Alarm Additions Author: Dan S <coke12oz@hotmail.com>
  *  Modified by Jordan <jordan@xeron.cc>
  *  Date: 2016-02-04
+ *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Smoke 2w", author: "jordan@xeron.cc", namespace: 'dsc') {
+  definition (name: "DSC Zone Smoke 2w", author: "jordan@xeron.cc", namespace: 'DSC') {
     // Change or define capabilities here as needed
     capability "Smoke Detector"
     capability "Sensor"
@@ -22,10 +23,12 @@ metadata {
 
   tiles {
     // Main Row
-    standardTile("zone", "device.smoke", width: 2, height: 2, canChangeBackground: true, canChangeIcon: true) {
-      state "clear",  label: 'clear',  icon: "st.alarm.smoke.clear", backgroundColor: "#ffffff"
-      state "smoke",  label: 'SMOKE',  icon: "st.alarm.smoke.smoke", backgroundColor: "#e86d13"
-      state "tested", label: 'TESTED', icon: "st.alarm.smoke.test",  backgroundColor: "#e86d13"
+    multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+        tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
+            attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
+            attributeState "smoke", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
+            attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
+        }
     }
 
     // This tile will be the tile that is displayed on the Hub page.

--- a/devicetypes/dsc/dsc-zone-smoke-4w.src/dsc-zone-smoke-4w.groovy
+++ b/devicetypes/dsc/dsc-zone-smoke-4w.src/dsc-zone-smoke-4w.groovy
@@ -5,11 +5,12 @@
  *  Originally by: Matt Martz <matt.martz@gmail.com>
  *  Modified by: Kent Holloway <drizit@gmail.com>
  *  Date: 2016-02-27
+ *  Cosmetically Tweaked By: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  */
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Smoke 4w", author: "jordan@xeron.cc", namespace: 'dsc') {
+  definition (name: "DSC Zone Smoke 4w", author: "jordan@xeron.cc", namespace: 'DSC') {
     // Change or define capabilities here as needed
     capability "Smoke Detector"
     capability "Sensor"
@@ -25,25 +26,29 @@ metadata {
   }
 
   tiles(scale: 2) {
-    standardTile ("zone", "device.smoke", width: 4, height: 4, title: "Zone") {
-      state "clear",  label: 'clear',  icon: "st.alarm.smoke.clear", backgroundColor: "#ffffff"
-      state "detected",  label: 'SMOKE',  icon: "st.alarm.smoke.smoke", backgroundColor: "#e86d13"
-      state "tested", label: 'TESTED', icon: "st.alarm.smoke.test",  backgroundColor: "#e86d13"
+  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+        tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
+            attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
+            attributeState "detected", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
+            attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
+        }
     }
     standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-      state "restore", label: 'No\u00A0Trouble', icon: "st.security.alarm.clear", backgroundColor: "#79b821"
+      state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
       state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
       state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
     }
     standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass"){
       state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
     }
-
+	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+	}
+    
     // This tile will be the tile that is displayed on the Hub page.
     main "zone"
 
     // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "trouble", "bypass"])
+    details(["zone", "spacerTile","trouble", "bypass", "spacerTile"])
   }
 }
 

--- a/devicetypes/dsc/dsc-zone-smoke-4w.src/dsc-zone-smoke-4w.groovy
+++ b/devicetypes/dsc/dsc-zone-smoke-4w.src/dsc-zone-smoke-4w.groovy
@@ -11,7 +11,7 @@
 // for the UI
 metadata {
   definition (name: "DSC Zone Smoke 4w", author: "jordan@xeron.cc", namespace: 'DSC') {
-    // Change or define capabilities here as needed
+		// Change or define capabilities here as needed
     capability "Smoke Detector"
     capability "Sensor"
     capability "Momentary"
@@ -41,8 +41,8 @@ metadata {
     standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass"){
       state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
     }
-	standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
-	}
+		standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
+		}
     
     // This tile will be the tile that is displayed on the Hub page.
     main "zone"
@@ -72,7 +72,8 @@ def zone(String state) {
   if (troubleList.contains(state)) {
     // Send final event
     sendEvent (name: "trouble", value: "${state}")
-  } else {
+  } 
+  else {
     // Since this is a smoke device we need to convert the values to match the device capabilities
     // before sending the event
     def eventMap = [

--- a/devicetypes/dsc/dsc-zone-smoke-4w.src/dsc-zone-smoke-4w.groovy
+++ b/devicetypes/dsc/dsc-zone-smoke-4w.src/dsc-zone-smoke-4w.groovy
@@ -10,46 +10,46 @@
 
 // for the UI
 metadata {
-  definition (name: "DSC Zone Smoke 4w", author: "jordan@xeron.cc", namespace: 'DSC') {
+	definition (name: "DSC Zone Smoke 4w", author: "jordan@xeron.cc", namespace: 'DSC') {
 		// Change or define capabilities here as needed
-    capability "Smoke Detector"
-    capability "Sensor"
-    capability "Momentary"
+		capability "Smoke Detector"
+		capability "Sensor"
+		capability "Momentary"
 
-    // Add commands as needed
-    command "zone"
-    command "bypass"
-  }
+		// Add commands as needed
+		command "zone"
+		command "bypass"
+	}
 
-  simulator {
-    // Nothing here, you could put some testing stuff here if you like
-  }
+	simulator {
+		// Nothing here, you could put some testing stuff here if you like
+	}
 
-  tiles(scale: 2) {
-  	multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
-        tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
-            attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
-            attributeState "detected", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
-            attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
-        }
-    }
-    standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
-      state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
-      state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
-      state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
-    }
-    standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass"){
-      state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
-    }
+	tiles(scale: 2) {
+		multiAttributeTile(name:"zone", type: "generic", width: 6, height: 4){
+			tileAttribute ("device.smoke", key: "PRIMARY_CONTROL") {
+				attributeState "clear", label:'Clear', icon:"st.alarm.smoke.clear", backgroundColor:"#ffffff"
+				attributeState "detected", label:'Smoke', icon:"st.alarm.smoke.smoke", backgroundColor:"#e86d13"
+				attributeState "tested", label:'Tested', icon:"st.alarm.smoke.test", backgroundColor:"#e86d13"
+			}
+		}
+		standardTile ("trouble", "device.trouble", width: 2, height: 2, title: "Trouble") {
+			state "restore", label: 'No Trouble', icon: "st.security.alarm.clear"
+			state "tamper", label: 'Tamper', icon: "st.security.alarm.alarm", backgroundColor: "#ffa81e"
+			state "fault", label: 'Fault', icon: "st.security.alarm.alarm", backgroundColor: "#ff1e1e"
+		}
+		standardTile("bypass", "capability.momentary", width: 2, height: 2, title: "Bypass"){
+			state "bypass", label: 'Bypass', action: "bypass", icon: "st.locks.lock.unlocked", backgroundColor: "#FFFF00"
+		}
 		standardTile("spacerTile", "spacerTile", decoration: "flat", width: 1, height: 2) {
 		}
     
-    // This tile will be the tile that is displayed on the Hub page.
-    main "zone"
+		// This tile will be the tile that is displayed on the Hub page.
+		main "zone"
 
-    // These tiles will be displayed when clicked on the device, in the order listed here.
-    details(["zone", "spacerTile","trouble", "bypass", "spacerTile"])
-  }
+		// These tiles will be displayed when clicked on the device, in the order listed here.
+		details(["zone", "spacerTile","trouble", "bypass", "spacerTile"])
+	}
 }
 
 // handle commands

--- a/smartapps/dsc/dsc-integration.src/dsc-integration.groovy
+++ b/smartapps/dsc/dsc-integration.src/dsc-integration.groovy
@@ -34,40 +34,40 @@ preferences {
   			metadata: [
 				values: ['Yes','No']
 			]
-    	input 'shmBypass', 'enum', title: 'SHM Stay/Away Bypass', required: false,
-      		metadata: [
-       			values: ['Yes','No']
-      		]
+		input 'shmBypass', 'enum', title: 'SHM Stay/Away Bypass', required: false,
+			metadata: [
+				values: ['Yes','No']
+			]
   	}
   	section('XBMC Notifications (optional):') {
-    	// TODO: put inputs here
-    	input 'xbmcserver', 'text', title: 'XBMC IP', description: 'IP Address', required: false
-    	input 'xbmcport', 'number', title: 'XBMC Port', description: 'Port', required: false
+		// TODO: put inputs here
+		input 'xbmcserver', 'text', title: 'XBMC IP', description: 'IP Address', required: false
+		input 'xbmcport', 'number', title: 'XBMC Port', description: 'Port', required: false
   	}
   	section('Notifications (optional)') {
-    	input 'sendPush', 'enum', title: 'Push Notification', required: false,
-      		metadata: [
-       			values: ['Yes','No']
-      		]
-        input 'phone1', 'phone', title: 'Phone Number', required: false
+		input 'sendPush', 'enum', title: 'Push Notification', required: false,
+			metadata: [
+				values: ['Yes','No']
+			]
+		input 'phone1', 'phone', title: 'Phone Number', required: false
   	}
   	section('Notification events (optional):') {
-    	input 'notifyEvents', 'enum', title: 'Which Events', description: 'Events to notify on', required: false, multiple: true,
-      		options: [
-        		'all', 'partition alarm', 'partition armed', 'partition away', 'partition disarm', 'partition duress',
-        		'partition entrydelay', 'partition exitdelay', 'partition forceready', 'partition instantaway',
-        		'partition instantstay', 'partition notready', 'partition ready', 'partition restore', 'partition stay',
-        		'partition trouble', 'partition keyfirealarm', 'partition keyfirerestore', 'partition keyauxalarm',
-        		'partition keyauxrestore', 'partition keypanicalarm', 'partition keypanicrestore', 'led backlight on',
-        		'led backlight off', 'led fire on', 'led fire off', 'led program on', 'led program off', 'led trouble on',
-        		'led trouble off', 'led bypass on', 'led bypass off', 'led memory on', 'led memory off', 'led armed on',
-        		'led armed off', 'led ready on', 'led ready off', 'zone alarm', 'zone clear', 'zone closed', 'zone fault',
-        		'zone open', 'zone restore', 'zone smoke', 'zone tamper'
-      		]
+		input 'notifyEvents', 'enum', title: 'Which Events', description: 'Events to notify on', required: false, multiple: true,
+			options: [
+				'all', 'partition alarm', 'partition armed', 'partition away', 'partition disarm', 'partition duress',
+				'partition entrydelay', 'partition exitdelay', 'partition forceready', 'partition instantaway',
+				'partition instantstay', 'partition notready', 'partition ready', 'partition restore', 'partition stay',
+				'partition trouble', 'partition keyfirealarm', 'partition keyfirerestore', 'partition keyauxalarm',
+				'partition keyauxrestore', 'partition keypanicalarm', 'partition keypanicrestore', 'led backlight on',
+				'led backlight off', 'led fire on', 'led fire off', 'led program on', 'led program off', 'led trouble on',
+				'led trouble off', 'led bypass on', 'led bypass off', 'led memory on', 'led memory off', 'led armed on',
+				'led armed off', 'led ready on', 'led ready off', 'zone alarm', 'zone clear', 'zone closed', 'zone fault',
+				'zone open', 'zone restore', 'zone smoke', 'zone tamper'
+			]
 		input 'includePartition', 'enum', title: 'Include Partition # in Notification', required: false,
 			metadata: [
 				values: ['Yes','No']
-      		]
+			]
   	}
 }
 

--- a/smartapps/dsc/dsc-integration.src/dsc-integration.groovy
+++ b/smartapps/dsc/dsc-integration.src/dsc-integration.groovy
@@ -4,239 +4,270 @@
  *  Author: Kent Holloway <drizit@gmail.com>
  *  Modified by: Matt Martz <matt.martz@gmail.com>
  *  Modified by: Jordan <jordan@xeron.cc>
+ *  Modified by: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
+ *		Changes:	Added Flood Sensor Type (define a flood sensor (DSC WS4985) in alarmserver.cfg as 'flood'
+ *					Fixed line identation
+ *					Customized alarm push messages to be more understandable for end users
+ *					Added a setting to show/not show partition number in notification messages
+ *					Fixed "notification" spelling error on line 46
  */
 
 definition(
-    name: 'DSC Integration',
-    namespace: 'dsc',
-    author: 'Jordan <jordan@xeron.cc>',
-    description: 'DSC Integration App',
-    category: 'My Apps',
-    iconUrl: 'https://dl.dropboxusercontent.com/u/2760581/dscpanel_small.png',
-    iconX2Url: 'https://dl.dropboxusercontent.com/u/2760581/dscpanel_large.png',
-    oauth: true,
-    singleInstance: true
+	name: 'DSC Integration',
+	namespace: 'DSC',
+	author: 'Jordan <jordan@xeron.cc>',
+	description: 'DSC Integration App',
+	category: 'My Apps',
+	iconUrl: 'https://dl.dropboxusercontent.com/u/2760581/dscpanel_small.png',
+	iconX2Url: 'https://dl.dropboxusercontent.com/u/2760581/dscpanel_large.png',
+	oauth: true,
+	singleInstance: true
 )
 
 import groovy.json.JsonBuilder
 
 preferences {
-  section('Alarmserver Setup:') {
-    input('ip', 'text', title: 'IP', description: 'The IP of your alarmserver (required)', required: false)
-    input('port', 'text', title: 'Port', description: 'The port (required)', required: false)
-    input 'shmSync', 'enum', title: 'Smart Home Monitor Sync', required: false,
-      metadata: [
-       values: ['Yes','No']
-      ]
-    input 'shmBypass', 'enum', title: 'SHM Stay/Away Bypass', required: false,
-      metadata: [
-       values: ['Yes','No']
-      ]
-  }
-  section('XBMC Notifications (optional):') {
-    // TODO: put inputs here
-    input 'xbmcserver', 'text', title: 'XBMC IP', description: 'IP Address', required: false
-    input 'xbmcport', 'number', title: 'XBMC Port', description: 'Port', required: false
-  }
-  section('Notifications (optional)') {
-    input 'sendPush', 'enum', title: 'Push Notifiation', required: false,
-      metadata: [
-       values: ['Yes','No']
-      ]
-    input 'phone1', 'phone', title: 'Phone Number', required: false
-  }
-  section('Notification events (optional):') {
-    input 'notifyEvents', 'enum', title: 'Which Events?', description: 'Events to notify on', required: false, multiple: true,
-      options: [
-        'all', 'partition alarm', 'partition armed', 'partition away', 'partition disarm', 'partition duress',
-        'partition entrydelay', 'partition exitdelay', 'partition forceready', 'partition instantaway',
-        'partition instantstay', 'partition notready', 'partition ready', 'partition restore', 'partition stay',
-        'partition trouble', 'partition keyfirealarm', 'partition keyfirerestore', 'partition keyauxalarm',
-        'partition keyauxrestore', 'partition keypanicalarm', 'partition keypanicrestore', 'led backlight on',
-        'led backlight off', 'led fire on', 'led fire off', 'led program on', 'led program off', 'led trouble on',
-        'led trouble off', 'led bypass on', 'led bypass off', 'led memory on', 'led memory off', 'led armed on',
-        'led armed off', 'led ready on', 'led ready off', 'zone alarm', 'zone clear', 'zone closed', 'zone fault',
-        'zone open', 'zone restore', 'zone smoke', 'zone tamper'
-      ]
-  }
+	section('Alarmserver Setup:') {
+		input('ip', 'text', title: 'IP', description: 'The IP of your alarmserver (required)', required: false)
+		input('port', 'text', title: 'Port', description: 'The port (required)', required: false)
+		input 'shmSync', 'enum', title: 'Smart Home Monitor Sync', required: false,
+  			metadata: [
+				values: ['Yes','No']
+			]
+    	input 'shmBypass', 'enum', title: 'SHM Stay/Away Bypass', required: false,
+      		metadata: [
+       			values: ['Yes','No']
+      		]
+  	}
+  	section('XBMC Notifications (optional):') {
+    	// TODO: put inputs here
+    	input 'xbmcserver', 'text', title: 'XBMC IP', description: 'IP Address', required: false
+    	input 'xbmcport', 'number', title: 'XBMC Port', description: 'Port', required: false
+  	}
+  	section('Notifications (optional)') {
+    	input 'sendPush', 'enum', title: 'Push Notification', required: false,
+      		metadata: [
+       			values: ['Yes','No']
+      		]
+        input 'phone1', 'phone', title: 'Phone Number', required: false
+  	}
+  	section('Notification events (optional):') {
+    	input 'notifyEvents', 'enum', title: 'Which Events', description: 'Events to notify on', required: false, multiple: true,
+      		options: [
+        		'all', 'partition alarm', 'partition armed', 'partition away', 'partition disarm', 'partition duress',
+        		'partition entrydelay', 'partition exitdelay', 'partition forceready', 'partition instantaway',
+        		'partition instantstay', 'partition notready', 'partition ready', 'partition restore', 'partition stay',
+        		'partition trouble', 'partition keyfirealarm', 'partition keyfirerestore', 'partition keyauxalarm',
+        		'partition keyauxrestore', 'partition keypanicalarm', 'partition keypanicrestore', 'led backlight on',
+        		'led backlight off', 'led fire on', 'led fire off', 'led program on', 'led program off', 'led trouble on',
+        		'led trouble off', 'led bypass on', 'led bypass off', 'led memory on', 'led memory off', 'led armed on',
+        		'led armed off', 'led ready on', 'led ready off', 'zone alarm', 'zone clear', 'zone closed', 'zone fault',
+        		'zone open', 'zone restore', 'zone smoke', 'zone tamper'
+      		]
+		input 'includePartition', 'enum', title: 'Include Partition # in Notification', required: false,
+			metadata: [
+				values: ['Yes','No']
+      		]
+  	}
 }
 
 mappings {
-  path('/update')            { action: [POST: 'update'] }
-  path('/installzones')      { action: [POST: 'installzones'] }
-  path('/installpartitions') { action: [POST: 'installpartitions'] }
+	path('/update')            { action: [POST: 'update'] }
+  	path('/installzones')      { action: [POST: 'installzones'] }
+  	path('/installpartitions') { action: [POST: 'installpartitions'] }
 }
 
 def initialize() {
-  if (settings.shmSync == 'Yes') {
-    subscribe(location, 'alarmSystemStatus', shmHandler)
-  }
+	
+    if (settings.shmSync == 'Yes') {
+    	subscribe(location, 'alarmSystemStatus', shmHandler)
+  	}
 }
 
 def shmHandler(evt) {
-  if (settings.shmSync == 'Yes') {
-    log.debug "shmHandler: shm changed state to: ${evt.value}"
-    def children = getChildDevices()
-    def child = children.find { item -> item.device.deviceNetworkId in ['dscstay1', 'dscaway1'] }
-    if (child != null) {
-      log.debug "shmHandler: using panel: ${child.device.deviceNetworkId} state: ${child.currentStatus}"
-      //map DSC states to simplified values for comparison
-      def dscMap = [
-        'alarm': 'on',
-        'away':'away',
-        'entrydelay': 'on',
-        'exitdelay': 'on',
-        'forceready':'off',
-        'instantaway':'away',
-        'instantstay':'stay',
-        'ready':'off',
-        'stay':'stay',
-      ]
+  
+	if (settings.shmSync == 'Yes') {
+    	
+		log.debug "shmHandler: shm changed state to: ${evt.value}"
+    	def children = getChildDevices()
+    	def child = children.find { item -> item.device.deviceNetworkId in ['dscstay1', 'dscaway1'] }
+    	if (child != null) {
+            log.debug "shmHandler: using panel: ${child.device.deviceNetworkId} state: ${child.currentStatus}"
+            //map DSC states to simplified values for comparison
+            def dscMap = [
+                'alarm': 'on',
+                'away':'away',
+                'entrydelay': 'on',
+                'exitdelay': 'on',
+                'forceready':'off',
+                'instantaway':'away',
+                'instantstay':'stay',
+                'ready':'off',
+                'stay':'stay',
+            ]
 
-      if (dscMap[child.currentStatus] && evt.value != dscMap[child.currentStatus]) {
-        if (evt.value == 'off' && dscMap[child.currentStatus] in ['stay', 'away', 'on'] ) {
-          sendUrl('disarm')
-          log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, disarm sent"
-        } else if (evt.value == 'away' && dscMap[child.currentStatus] in ['stay', 'off'] ) {
-          sendUrl('arm')
-          log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, arm sent"
-        } else if (evt.value == 'stay' && dscMap[child.currentStatus] in ['away', 'off'] ) {
-          sendUrl('stayarm')
-          log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, stayarm sent"
-        }
-      }
-    }
-  }
+            if (dscMap[child.currentStatus] && evt.value != dscMap[child.currentStatus]) {
+                if (evt.value == 'off' && dscMap[child.currentStatus] in ['stay', 'away', 'on'] ) {
+                    sendUrl('disarm')
+                    log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, disarm sent"
+                } 
+                else if (evt.value == 'away' && dscMap[child.currentStatus] in ['stay', 'off'] ) {
+                    sendUrl('arm')
+                    log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, arm sent"
+                } 
+                else if (evt.value == 'stay' && dscMap[child.currentStatus] in ['away', 'off'] ) {
+                    sendUrl('stayarm')
+                    log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, stayarm sent"
+                }
+            }
+    	}
+  	}
 }
 
 def installzones() {
-  def children = getChildDevices()
-  def zones = request.JSON
+	
+    def children = getChildDevices()
+  	def zones = request.JSON
 
-  def zoneMap = [
-    'contact':'DSC Zone Contact',
-    'motion':'DSC Zone Motion',
-    'smoke':'DSC Zone Smoke',
-    'co':'DSC Zone CO',
-  ]
+  	def zoneMap = [
+    	'contact':'DSC Zone Contact',
+    	'motion':'DSC Zone Motion',
+    	'smoke':'DSC Zone Smoke',
+    	'co':'DSC Zone CO',
+    	'flood':'DSC Zone Flood',
+  	]
 
-  log.debug "children are ${children}"
-  for (zone in zones) {
-    def id = zone.key
-    def type = zone.value.'type'
-    def device = zoneMap."${type}"
-    def name = zone.value.'name'
-    def networkId = "dsczone${id}"
-    def zoneDevice = children.find { item -> item.device.deviceNetworkId == networkId }
+  	log.debug "children are ${children}"
+  	for (zone in zones) {
+	    def id = zone.key
+    	def type = zone.value.'type'
+    	def device = zoneMap."${type}"
+    	def name = zone.value.'name'
+    	def networkId = "dsczone${id}"
+    	def zoneDevice = children.find { item -> item.device.deviceNetworkId == networkId }
 
-    if (zoneDevice == null) {
-      log.debug "add new child: device: ${device} networkId: ${networkId} name: ${name}"
-      zoneDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
-    } else {
-      log.debug "zone device was ${zoneDevice}"
-      try {
-        log.debug "trying name update for ${networkId}"
-        zoneDevice.name = "${name}"
-        log.debug "trying label update for ${networkId}"
-        zoneDevice.label = "${name}"
-      } catch(IllegalArgumentException e) {
-        log.debug "excepted for ${networkId}"
-         if ("${e}".contains('identifier required')) {
-           log.debug "Attempted update but device didn't exist. Creating ${networkId}"
-           zoneDevice = addChildDevice("dsc", "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
-         } else {
-           log.error "${e}"
-         }
-      }
-    }
-  }
+    	if (zoneDevice == null) {
+      		log.debug "add new child: device: ${device} networkId: ${networkId} name: ${name}"
+      		zoneDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
+    	} 
+        else {
+      		log.debug "zone device was ${zoneDevice}"
+      		try {
+        		log.debug "trying name update for ${networkId}"
+        		zoneDevice.name = "${name}"
+        		log.debug "trying label update for ${networkId}"
+        		zoneDevice.label = "${name}"
+      		} 
+            catch(IllegalArgumentException e) {
+        		log.debug "excepted for ${networkId}"
+         		if ("${e}".contains('identifier required')) {
+           			log.debug "Attempted update but device didn't exist. Creating ${networkId}"
+           			zoneDevice = addChildDevice("dsc", "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
+         		} 
+                else {
+           			log.error "${e}"
+         		}
+      		}
+    	}
+  	}
 
-  for (child in children) {
-    if (child.device.deviceNetworkId.contains('dsczone')) {
-      def zone = child.device.deviceNetworkId.minus('dsczone')
-      def jsonZone = zones.find { x -> "${x.key}" == "${zone}"}
-      if (jsonZone == null) {
-        try {
-          log.debug "Deleting device ${child.device.deviceNetworkId} ${child.device.name} as it was not in the config"
-          deleteChildDevice(child.device.deviceNetworkId)
-        } catch(MissingMethodException e) {
-          if ("${e}".contains('types: (null) values: [null]')) {
-            log.debug "Device ${child.device.deviceNetworkId} was empty, likely deleted already."
-          } else {
-             log.error e
-          }
+	for (child in children) {
+    	if (child.device.deviceNetworkId.contains('dsczone')) {
+      		def zone = child.device.deviceNetworkId.minus('dsczone')
+      		def jsonZone = zones.find { x -> "${x.key}" == "${zone}"}
+      		
+            if (jsonZone == null) {
+        		try {
+          			log.debug "Deleting device ${child.device.deviceNetworkId} ${child.device.name} as it was not in the config"
+          			deleteChildDevice(child.device.deviceNetworkId)
+        		} 
+                catch(MissingMethodException e) {
+          			if ("${e}".contains('types: (null) values: [null]')) {
+            			log.debug "Device ${child.device.deviceNetworkId} was empty, likely deleted already."
+          			} 
+                	else {
+             			log.error e
+          			}
+        		}
+      		}
         }
-      }
-    }
-  }
+  	}
 }
 
 def installpartitions() {
-  def children = getChildDevices()
-  def partitions = request.JSON
+ 	
+    def children = getChildDevices()
+  	def partitions = request.JSON
 
-  def partMap = [
-    'stay':'DSC Stay Panel',
-    'away':'DSC Away Panel',
-  ]
+  	def partMap = [
+    	'stay':'DSC Stay Panel',
+    	'away':'DSC Away Panel',
+  	]
 
-  log.debug "children are ${children}"
-  for (part in partitions) {
-    def id = part.key
+  	log.debug "children are ${children}"
+  	for (part in partitions) {
+	    def id = part.key
 
-    for (p in part.value) {
-      def type = p.key
-      def name = p.value
-      def networkId = "dsc${type}${id}"
-      def partDevice = children.find { item -> item.device.deviceNetworkId == networkId }
-      def device = partMap."${type}"
+    	for (p in part.value) {
+      		def type = p.key
+      		def name = p.value
+      		def networkId = "dsc${type}${id}"
+      		def partDevice = children.find { item -> item.device.deviceNetworkId == networkId }
+      		def device = partMap."${type}"
 
-      if (partDevice == null) {
-        log.debug "add new child: device: ${device} networkId: ${networkId} name: ${name}"
-        partDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
-      } else {
-        log.debug "part device was ${partDevice}"
-        try {
-          log.debug "trying name update for ${networkId}"
-          partDevice.name = "${name}"
-          log.debug "trying label update for ${networkId}"
-          partDevice.label = "${name}"
-        } catch(IllegalArgumentException e) {
-          log.debug "excepted for ${networkId}"
-           if ("${e}".contains('identifier required')) {
-             log.debug "Attempted update but device didn't exist. Creating ${networkId}"
-             partDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
-           } else {
-             log.error "${e}"
-           }
-        }
-      }
-    }
-  }
+      		if (partDevice == null) {
+        		log.debug "add new child: device: ${device} networkId: ${networkId} name: ${name}"
+        		partDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
+      		} 
+            else {
+        		log.debug "part device was ${partDevice}"
+        		try {
+          			log.debug "trying name update for ${networkId}"
+          			partDevice.name = "${name}"
+          			log.debug "trying label update for ${networkId}"
+          			partDevice.label = "${name}"
+        		} 
+                catch(IllegalArgumentException e) {
+          			log.debug "excepted for ${networkId}"
+           			if ("${e}".contains('identifier required')) {
+             			log.debug "Attempted update but device didn't exist. Creating ${networkId}"
+             			partDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
+           			} 
+                    else {
+             			log.error "${e}"
+           			}
+        		}
+      		}
+    	}
+	}
 
-  for (child in children) {
-    for (p in ['stay', 'away']) {
-        if (child.device.deviceNetworkId.contains("dsc${p}")) {
-        def part = child.device.deviceNetworkId.minus("dsc${p}")
-        def jsonPart = partitions.find { x -> x.value."${p}" }
-        if (jsonPart== null) {
-          try {
-            log.debug "Deleting device ${child.device.deviceNetworkId} ${child.device.name} as it was not in the config"
-            deleteChildDevice(child.device.deviceNetworkId)
-          } catch(MissingMethodException e) {
-            if ("${e}".contains('types: (null) values: [null]')) {
-              log.debug "Device ${child.device.deviceNetworkId} was empty, likely deleted already."
-            } else {
-              log.error e
-            }
-          }
-        }
-      }
-    }
-  }
+  	for (child in children) {
+    	for (p in ['stay', 'away']) {
+        	if (child.device.deviceNetworkId.contains("dsc${p}")) {
+        		def part = child.device.deviceNetworkId.minus("dsc${p}")
+        		def jsonPart = partitions.find { x -> x.value."${p}" }
+        		if (jsonPart== null) {
+          			try {
+            			log.debug "Deleting device ${child.device.deviceNetworkId} ${child.device.name} as it was not in the config"
+            			deleteChildDevice(child.device.deviceNetworkId)
+          			} 
+                    catch(MissingMethodException e) {
+            			if ("${e}".contains('types: (null) values: [null]')) {
+              				log.debug "Device ${child.device.deviceNetworkId} was empty, likely deleted already."
+            			} 
+                        else {
+              				log.error e
+            			}
+          			}
+        		}
+      		}
+    	}
+  	}
 }
 
 def sendUrl(url) {
+	
+    log.debug "sendUrl(" + url + ")"
     def result = new physicalgraph.device.HubAction(
         method: 'GET',
         path: "/api/alarm/${url}",
@@ -246,110 +277,210 @@ def sendUrl(url) {
     )
 	sendHubCommand(result)
 	log.debug 'response' : "Request to send url: ${url} received"
+    
     return result
 }
 
 
 def installed() {
-  log.debug 'Installed!'
+  	log.debug 'Installed!'
+}
+
+def testFunction() {
+	log.debug "Test Function"
 }
 
 def updated() {
-  unsubscribe()
-  unschedule()
-  initialize()
-  log.debug 'Updated!'
+  	unsubscribe()
+  	unschedule()
+  	initialize()
+  	log.debug 'Updated!'
 }
 
 private update() {
-  def update = request.JSON
 
-  if (update.'parameters') {
-    for (p in update.'parameters') {
-      if (notifyEvents && (notifyEvents.contains('all') || notifyEvents.contains("led ${p.key} ${p.value}".toString()))) {
-        sendMessage("${update.'type'} ${update.'value'} in ${update.'status'} ${p.key} ${p.value} state")
-      }
-    }
-  } else {
-    if (notifyEvents && (notifyEvents.contains('all') || notifyEvents.contains("${update.'type'} ${update.'status'}".toString()))) {
-      sendMessage("${update.'type'} ${update.'value'} in ${update.'status'} state")
-    }
-  }
-  if ("${update.'type'}" == 'zone') {
-    updateZoneDevices(update.'value', update.'status')
-  } else if ("${update.'type'}" == 'partition') {
-    if (settings.shmSync == 'Yes') {
-      // Map DSC states to SHM modes, only using absolute states for now, no exit/entry delay
-      def shmMap = [
-        'away':'away',
-        'forceready':'off',
-        'instantaway':'away',
-        'instantstay':'stay',
-        'notready':'off',
-        'ready':'off',
-        'stay':'stay',
-      ]
+	def update = request.JSON
 
-      if (shmMap[update.'status']) {
-        if (settings.shmBypass != 'Yes' || !(location.currentState("alarmSystemStatus")?.value in ['away','stay'] && shmMap[update.'status'] in ['away','stay'])) {
-          log.debug "sending smart home monitor: ${shmMap[update.'status']} for status: ${update.'status'}"
-          sendLocationEvent(name: "alarmSystemStatus", value: shmMap[update.'status'])
-        }
-      }
+	//If the update contains parameters (LED on Panel Update)
+	if (update.'parameters') {
+		for (p in update.'parameters') {
+			if (notifyEvents && (notifyEvents.contains('all') || notifyEvents.contains("led ${p.key} ${p.value}".toString()))) {
+            	
+                def messageBody = "Keypad LED ${p.key} in ${p.value} state"
+                
+                if (includePartition == 'Yes')
+                    messageBody += " (Partition: ${update.'value'})"
+                    
+                sendMessage(messageBody)
+			}
+		}
+	} 
+  
+	//If the update does not contain parameters
+	else {
+		if (notifyEvents && (notifyEvents.contains('all') || notifyEvents.contains("${update.'type'} ${update.'status'}".toString()))) {
+      		
+            if ("${update.'type'}" == 'partition') {
+            
+            	def messageBody = "Alarm in ${update.'status'} state"
+                
+            	if ("${update.'status'}" == 'alarm')
+                    messageBody = "Alarm is active!"
+                else if ("${update.'status'}" == 'armed')
+                    messageBody = "Alarm is armed"
+                else if ("${update.'status'}" == 'away')
+                    messageBody = "Alarm is armed/away"
+                else if ("${update.'status'}" == 'disarm')
+                    messageBody = "Alarm is disarmed"
+                else if ("${update.'status'}" == 'duress')
+                    messageBody = "Alarm is in a state of duress"
+                else if ("${update.'status'}" == 'entrydelay')
+                    messageBody = "Entry delay in progress"
+                else if ("${update.'status'}" == 'exitdelay')
+                    messageBody = "Exit delay in progress" 
+				else if ("${update.'status'}" == 'forceready')
+                    messageBody = "Alarm has been forced ready"
+				else if ("${update.'status'}" == 'instantaway')
+                    messageBody = "Alarm has been set to instant away"
+				else if ("${update.'status'}" == 'instantstay')
+                    messageBody = "Alarm has been set to instant stay"
+				else if ("${update.'status'}" == 'notready')
+                    messageBody = "Alarm is not ready"
+				else if ("${update.'status'}" == 'ready')
+                    messageBody = "Alarm is ready"
+				else if ("${update.'status'}" == 'restore')
+                    messageBody = "Alarm has been restored"
+				else if ("${update.'status'}" == 'stay')
+                    messageBody = "Alarm is armed/stay"
+				else if ("${update.'status'}" == 'trouble')
+                    messageBody = "Alarm has a trouble status"
+				else if ("${update.'status'}" == 'keyfirealarm')
+                    messageBody = "Fire alarm key pressed on alarm"
+				else if ("${update.'status'}" == 'keyfirerestore')
+                    messageBody = "Fire alarm key restored on alarm"
+				else if ("${update.'status'}" == 'keyauxalarm')
+                    messageBody = "Auxiliary alarm key pressed on alarm"
+				else if ("${update.'status'}" == 'keyauxrestore')
+                    messageBody = "Auxiliary alarm key restored on alarm"
+				else if ("${update.'status'}" == 'keypanicalarm')
+                    messageBody = "Panic key pressed on alarm"
+				else if ("${update.'status'}" == 'keypanicrestore')
+                    messageBody = "Panic key restored on alarm"
+                
+                if (includePartition == 'Yes')
+                    messageBody += " (Partition: ${update.'value'})"
+                    
+                sendMessage(messageBody)
+            }
+            
+            else if ("${update.'type'}" == 'zone') {
+            
+                if ("${update.'status'}" == 'clear')
+                    sendMessage("Zone ${update.'value'} is clear")
+				else if ("${update.'status'}" == 'closed')
+                    sendMessage("Zone ${update.'value'} is closed")
+                else if ("${update.'status'}" == 'fault')
+                    sendMessage("Zone ${update.'value'} is in fault")
+                else if ("${update.'status'}" == 'open')
+                    sendMessage("Zone ${update.'value'} is open")
+                else if ("${update.'status'}" == 'restore')
+                    sendMessage("Zone ${update.'value'} has been restored")
+                else if ("${update.'status'}" == 'smoke')
+                    sendMessage("Smoke detected in zone ${update.'value'}")
+                else if ("${update.'status'}" == 'tamper')
+                    sendMessage("Zone ${update.'value'} has been tampered with")
+                else
+                    sendMessage("Zone ${update.'value'} in ${update.'status'} state")
+            }
+    	}
     }
-    updatePartitions(update.'value', update.'status', update.'parameters')
-  }
+  
+	if ("${update.'type'}" == 'zone') {
+		updateZoneDevices(update.'value', update.'status')
+	}
+  
+	else if ("${update.'type'}" == 'partition') {
+    	if (settings.shmSync == 'Yes') {
+      		// Map DSC states to SHM modes, only using absolute states for now, no exit/entry delay
+      		def shmMap = [
+        		'away':'away',
+        		'forceready':'off',
+				'instantaway':'away',
+        		'instantstay':'stay',
+        		'notready':'off',
+        		'ready':'off',
+        		'stay':'stay',
+      		]
+
+            if (shmMap[update.'status']) {
+                if (settings.shmBypass != 'Yes' || !(location.currentState("alarmSystemStatus")?.value in ['away','stay'] && shmMap[update.'status'] in ['away','stay'])) {
+                    log.debug "sending smart home monitor: ${shmMap[update.'status']} for status: ${update.'status'}"
+                    sendLocationEvent(name: "alarmSystemStatus", value: shmMap[update.'status'])
+                }
+            }
+		}
+    	updatePartitions(update.'value', update.'status', update.'parameters')
+  	}
 }
 
 private updateZoneDevices(zonenum,zonestatus) {
-  def children = getChildDevices()
-  log.debug "zone: ${zonenum} is ${zonestatus}"
-  // log.debug "zonedevices.id are $zonedevices.id"
-  // log.debug "zonedevices.displayName are $zonedevices.displayName"
-  // log.debug "zonedevices.deviceNetworkId are $zonedevices.deviceNetworkId"
-  def zonedevice = children.find { item -> item.device.deviceNetworkId == "dsczone${zonenum}"}
-  //def zonedevice = zonedevices.find { it.deviceNetworkId == "dsczone${zonenum}" }
-  if (zonedevice) {
-    log.debug "Was True... Zone Device: $zonedevice.displayName at $zonedevice.deviceNetworkId is ${zonestatus}"
-    //Was True... Zone Device: Front Door Sensor at zone1 is closed
-    zonedevice.zone("${zonestatus}")
-    if ("${settings.xbmcserver}" != "") {  //Note: I haven't tested this if statement, but it looks like it would work.
-      def lanaddress = "${settings.xbmcserver}:${settings.xbmcport}"
-      def deviceNetworkId = "1234"
-      def json = new JsonBuilder()
-      def messagetitle = "$zonedevice.displayName".replaceAll(' ','%20')
-      log.debug "$messagetitle"
-      json.call("jsonrpc":"2.0","method":"GUI.ShowNotification","params":[title: "$messagetitle",message: "${zonestatus}"],"id":1)
-      def xbmcmessage = "/jsonrpc?request="+json.toString()
-      def result = new physicalgraph.device.HubAction("""GET $xbmcmessage HTTP/1.1\r\nHOST: $lanaddress\r\n\r\n""", physicalgraph.device.Protocol.LAN, "${deviceNetworkId}")
-      sendHubCommand(result)
-    }
-  }
+	
+    def children = getChildDevices()
+  	log.debug "zone: ${zonenum} is ${zonestatus}"
+  	// log.debug "zonedevices.id are $zonedevices.id"
+  	// log.debug "zonedevices.displayName are $zonedevices.displayName"
+  	// log.debug "zonedevices.deviceNetworkId are $zonedevices.deviceNetworkId"
+  	def zonedevice = children.find { item -> item.device.deviceNetworkId == "dsczone${zonenum}"}
+  	//def zonedevice = zonedevices.find { it.deviceNetworkId == "dsczone${zonenum}" }
+  	
+    if (zonedevice) {
+    	log.debug "Was True... Zone Device: $zonedevice.displayName at $zonedevice.deviceNetworkId is ${zonestatus}"
+    	//Was True... Zone Device: Front Door Sensor at zone1 is closed
+    	zonedevice.zone("${zonestatus}")
+    
+    	if ("${settings.xbmcserver}" != "") {  //Note: I haven't tested this if statement, but it looks like it would work.
+      		def lanaddress = "${settings.xbmcserver}:${settings.xbmcport}"
+      		def deviceNetworkId = "1234"
+      		def json = new JsonBuilder()
+      		def messagetitle = "$zonedevice.displayName".replaceAll(' ','%20')
+      		log.debug "$messagetitle"
+      		json.call("jsonrpc":"2.0","method":"GUI.ShowNotification","params":[title: "$messagetitle",message: "${zonestatus}"],"id":1)
+      		def xbmcmessage = "/jsonrpc?request="+json.toString()
+      		def result = new physicalgraph.device.HubAction("""GET $xbmcmessage HTTP/1.1\r\nHOST: $lanaddress\r\n\r\n""", physicalgraph.device.Protocol.LAN, "${deviceNetworkId}")
+      		sendHubCommand(result)
+    	}
+  	}
 }
 
 private updatePartitions(partitionnum, partitionstatus, partitionparams) {
-  def children = getChildDevices()
-  log.debug "partition: ${partitionnum} is ${partitionstatus}"
-  def awaypanel = children.find { item -> item.device.deviceNetworkId == "dscaway${partitionnum}"}
-  if (awaypanel) {
-    log.debug "Was True... Away Switch device: $awaypanel.displayName at $awaypanel.deviceNetworkId is ${partitionstatus}"
-    //Was True... Zone Device: Front Door Sensor at zone1 is closed
-    awaypanel.partition("${partitionstatus}", "${partitionnum}", partitionparams)
-  }
-  def staypanel = children.find { item -> item.device.deviceNetworkId == "dscstay${partitionnum}"}
-  if (staypanel) {
-    log.debug "Was True... Stay Switch device: $staypanel.displayName at $staypanel.deviceNetworkId is ${partitionstatus}"
-    //Was True... Zone Device: Front Door Sensor at zone1 is closed
-    staypanel.partition("${partitionstatus}", "${partitionnum}", partitionparams)
-  }
+	
+    def children = getChildDevices()
+  	log.debug "partition: ${partitionnum} is ${partitionstatus}"
+  	
+    def awaypanel = children.find { item -> item.device.deviceNetworkId == "dscaway${partitionnum}"}
+  	if (awaypanel) {
+    	log.debug "Was True... Away Switch device: $awaypanel.displayName at $awaypanel.deviceNetworkId is ${partitionstatus}"
+    	//Was True... Zone Device: Front Door Sensor at zone1 is closed
+    	awaypanel.partition("${partitionstatus}", "${partitionnum}", partitionparams)
+  	}
+  	
+    def staypanel = children.find { item -> item.device.deviceNetworkId == "dscstay${partitionnum}"}
+  	if (staypanel) {
+    	log.debug "Was True... Stay Switch device: $staypanel.displayName at $staypanel.deviceNetworkId is ${partitionstatus}"
+    	//Was True... Zone Device: Front Door Sensor at zone1 is closed
+    	staypanel.partition("${partitionstatus}", "${partitionnum}", partitionparams)
+  	}
 }
 
 private sendMessage(msg) {
-  def newMsg = "Alarm Notification: $msg"
-  if (phone1) {
-    sendSms(phone1, newMsg)
-  }
-  if (sendPush == 'Yes') {
-    sendPush(newMsg)
-  }
+	
+    def newMsg = "Alarm Notification: $msg"
+  	
+    if (phone1) {
+	    sendSms(phone1, newMsg)
+  	}
+  	
+    if (sendPush == 'Yes') {
+    	sendPush(newMsg)
+  	}
 }

--- a/smartapps/dsc/dsc-integration.src/dsc-integration.groovy
+++ b/smartapps/dsc/dsc-integration.src/dsc-integration.groovy
@@ -79,211 +79,211 @@ mappings {
 
 def initialize() {
 	
-    if (settings.shmSync == 'Yes') {
-    	subscribe(location, 'alarmSystemStatus', shmHandler)
-  	}
+    	if (settings.shmSync == 'Yes') {
+    		subscribe(location, 'alarmSystemStatus', shmHandler)
+	}
 }
 
 def shmHandler(evt) {
   
 	if (settings.shmSync == 'Yes') {
-    	
-		log.debug "shmHandler: shm changed state to: ${evt.value}"
-    	def children = getChildDevices()
-    	def child = children.find { item -> item.device.deviceNetworkId in ['dscstay1', 'dscaway1'] }
-    	if (child != null) {
-            log.debug "shmHandler: using panel: ${child.device.deviceNetworkId} state: ${child.currentStatus}"
-            //map DSC states to simplified values for comparison
-            def dscMap = [
-                'alarm': 'on',
-                'away':'away',
-                'entrydelay': 'on',
-                'exitdelay': 'on',
-                'forceready':'off',
-                'instantaway':'away',
-                'instantstay':'stay',
-                'ready':'off',
-                'stay':'stay',
-            ]
 
-            if (dscMap[child.currentStatus] && evt.value != dscMap[child.currentStatus]) {
-                if (evt.value == 'off' && dscMap[child.currentStatus] in ['stay', 'away', 'on'] ) {
-                    sendUrl('disarm')
-                    log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, disarm sent"
-                } 
-                else if (evt.value == 'away' && dscMap[child.currentStatus] in ['stay', 'off'] ) {
-                    sendUrl('arm')
-                    log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, arm sent"
-                } 
-                else if (evt.value == 'stay' && dscMap[child.currentStatus] in ['away', 'off'] ) {
-                    sendUrl('stayarm')
-                    log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, stayarm sent"
-                }
-            }
-    	}
+		log.debug "shmHandler: shm changed state to: ${evt.value}"
+		def children = getChildDevices()
+		def child = children.find { item -> item.device.deviceNetworkId in ['dscstay1', 'dscaway1'] }
+		if (child != null) {
+			log.debug "shmHandler: using panel: ${child.device.deviceNetworkId} state: ${child.currentStatus}"
+			//map DSC states to simplified values for comparison
+			def dscMap = [
+				'alarm': 'on',
+				'away':'away',
+				'entrydelay': 'on',
+				'exitdelay': 'on',
+				'forceready':'off',
+				'instantaway':'away',
+				'instantstay':'stay',
+				'ready':'off',
+				'stay':'stay',
+			]
+
+			if (dscMap[child.currentStatus] && evt.value != dscMap[child.currentStatus]) {
+				if (evt.value == 'off' && dscMap[child.currentStatus] in ['stay', 'away', 'on'] ) {
+					sendUrl('disarm')
+					log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, disarm sent"
+				} 
+				else if (evt.value == 'away' && dscMap[child.currentStatus] in ['stay', 'off'] ) {
+					sendUrl('arm')
+					log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, arm sent"
+				} 
+				else if (evt.value == 'stay' && dscMap[child.currentStatus] in ['away', 'off'] ) {
+					sendUrl('stayarm')
+					log.debug "shmHandler: ${evt.value} is valid action for ${child.currentStatus}, stayarm sent"
+				}
+			}
+		}
   	}
 }
 
 def installzones() {
 	
-    def children = getChildDevices()
-  	def zones = request.JSON
+	def children = getChildDevices()
+	def zones = request.JSON
 
-  	def zoneMap = [
-    	'contact':'DSC Zone Contact',
-    	'motion':'DSC Zone Motion',
-    	'smoke':'DSC Zone Smoke',
-    	'co':'DSC Zone CO',
-    	'flood':'DSC Zone Flood',
-  	]
+	def zoneMap = [
+		'contact':'DSC Zone Contact',
+		'motion':'DSC Zone Motion',
+		'smoke':'DSC Zone Smoke',
+		'co':'DSC Zone CO',
+		'flood':'DSC Zone Flood',
+	]
 
-  	log.debug "children are ${children}"
-  	for (zone in zones) {
-	    def id = zone.key
-    	def type = zone.value.'type'
-    	def device = zoneMap."${type}"
-    	def name = zone.value.'name'
-    	def networkId = "dsczone${id}"
-    	def zoneDevice = children.find { item -> item.device.deviceNetworkId == networkId }
+	log.debug "children are ${children}"
+	for (zone in zones) {
+		def id = zone.key
+		def type = zone.value.'type'
+		def device = zoneMap."${type}"
+		def name = zone.value.'name'
+		def networkId = "dsczone${id}"
+		def zoneDevice = children.find { item -> item.device.deviceNetworkId == networkId }
 
-    	if (zoneDevice == null) {
-      		log.debug "add new child: device: ${device} networkId: ${networkId} name: ${name}"
-      		zoneDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
-    	} 
-        else {
-      		log.debug "zone device was ${zoneDevice}"
-      		try {
-        		log.debug "trying name update for ${networkId}"
-        		zoneDevice.name = "${name}"
-        		log.debug "trying label update for ${networkId}"
-        		zoneDevice.label = "${name}"
-      		} 
-            catch(IllegalArgumentException e) {
-        		log.debug "excepted for ${networkId}"
-         		if ("${e}".contains('identifier required')) {
-           			log.debug "Attempted update but device didn't exist. Creating ${networkId}"
-           			zoneDevice = addChildDevice("dsc", "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
-         		} 
-                else {
-           			log.error "${e}"
-         		}
-      		}
-    	}
+		if (zoneDevice == null) {
+			log.debug "add new child: device: ${device} networkId: ${networkId} name: ${name}"
+			zoneDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
+		} 
+		else {
+			log.debug "zone device was ${zoneDevice}"
+			try {
+				log.debug "trying name update for ${networkId}"
+				zoneDevice.name = "${name}"
+				log.debug "trying label update for ${networkId}"
+				zoneDevice.label = "${name}"
+			} 
+			catch(IllegalArgumentException e) {
+				log.debug "excepted for ${networkId}"
+				if ("${e}".contains('identifier required')) {
+					log.debug "Attempted update but device didn't exist. Creating ${networkId}"
+					zoneDevice = addChildDevice("dsc", "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
+				} 
+				else {
+					log.error "${e}"
+				}
+			}
+		}
   	}
 
 	for (child in children) {
-    	if (child.device.deviceNetworkId.contains('dsczone')) {
-      		def zone = child.device.deviceNetworkId.minus('dsczone')
-      		def jsonZone = zones.find { x -> "${x.key}" == "${zone}"}
+		if (child.device.deviceNetworkId.contains('dsczone')) {
+			def zone = child.device.deviceNetworkId.minus('dsczone')
+			def jsonZone = zones.find { x -> "${x.key}" == "${zone}"}
       		
-            if (jsonZone == null) {
-        		try {
-          			log.debug "Deleting device ${child.device.deviceNetworkId} ${child.device.name} as it was not in the config"
-          			deleteChildDevice(child.device.deviceNetworkId)
-        		} 
-                catch(MissingMethodException e) {
-          			if ("${e}".contains('types: (null) values: [null]')) {
-            			log.debug "Device ${child.device.deviceNetworkId} was empty, likely deleted already."
-          			} 
-                	else {
-             			log.error e
-          			}
-        		}
-      		}
-        }
-  	}
+			if (jsonZone == null) {
+				try {
+					log.debug "Deleting device ${child.device.deviceNetworkId} ${child.device.name} as it was not in the config"
+					deleteChildDevice(child.device.deviceNetworkId)
+				} 
+				catch(MissingMethodException e) {
+					if ("${e}".contains('types: (null) values: [null]')) {
+						log.debug "Device ${child.device.deviceNetworkId} was empty, likely deleted already."
+					} 
+					else {
+						log.error e
+					}
+				}
+			}
+		}
+	}
 }
 
 def installpartitions() {
  	
-    def children = getChildDevices()
-  	def partitions = request.JSON
+	def children = getChildDevices()
+	def partitions = request.JSON
 
-  	def partMap = [
-    	'stay':'DSC Stay Panel',
-    	'away':'DSC Away Panel',
-  	]
+	def partMap = [
+		'stay':'DSC Stay Panel',
+		'away':'DSC Away Panel',
+	]
 
-  	log.debug "children are ${children}"
-  	for (part in partitions) {
-	    def id = part.key
+	log.debug "children are ${children}"
+	for (part in partitions) {
+		def id = part.key
 
-    	for (p in part.value) {
-      		def type = p.key
-      		def name = p.value
-      		def networkId = "dsc${type}${id}"
-      		def partDevice = children.find { item -> item.device.deviceNetworkId == networkId }
-      		def device = partMap."${type}"
+		for (p in part.value) {
+			def type = p.key
+			def name = p.value
+			def networkId = "dsc${type}${id}"
+			def partDevice = children.find { item -> item.device.deviceNetworkId == networkId }
+			def device = partMap."${type}"
 
-      		if (partDevice == null) {
-        		log.debug "add new child: device: ${device} networkId: ${networkId} name: ${name}"
-        		partDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
-      		} 
-            else {
-        		log.debug "part device was ${partDevice}"
-        		try {
-          			log.debug "trying name update for ${networkId}"
-          			partDevice.name = "${name}"
-          			log.debug "trying label update for ${networkId}"
-          			partDevice.label = "${name}"
-        		} 
-                catch(IllegalArgumentException e) {
-          			log.debug "excepted for ${networkId}"
-           			if ("${e}".contains('identifier required')) {
-             			log.debug "Attempted update but device didn't exist. Creating ${networkId}"
-             			partDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
-           			} 
-                    else {
-             			log.error "${e}"
-           			}
-        		}
-      		}
-    	}
+			if (partDevice == null) {
+				log.debug "add new child: device: ${device} networkId: ${networkId} name: ${name}"
+				partDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
+			} 
+			else {
+				log.debug "part device was ${partDevice}"
+				try {
+					log.debug "trying name update for ${networkId}"
+					partDevice.name = "${name}"
+					log.debug "trying label update for ${networkId}"
+					partDevice.label = "${name}"
+				} 
+				catch(IllegalArgumentException e) {
+					log.debug "excepted for ${networkId}"
+					if ("${e}".contains('identifier required')) {
+						log.debug "Attempted update but device didn't exist. Creating ${networkId}"
+						partDevice = addChildDevice('dsc', "${device}", networkId, null, [name: "${name}", label:"${name}", completedSetup: true])
+					} 
+					else {
+             					log.error "${e}"
+           				}
+				}
+			}
+		}
 	}
 
-  	for (child in children) {
-    	for (p in ['stay', 'away']) {
-        	if (child.device.deviceNetworkId.contains("dsc${p}")) {
-        		def part = child.device.deviceNetworkId.minus("dsc${p}")
-        		def jsonPart = partitions.find { x -> x.value."${p}" }
-        		if (jsonPart== null) {
-          			try {
-            			log.debug "Deleting device ${child.device.deviceNetworkId} ${child.device.name} as it was not in the config"
-            			deleteChildDevice(child.device.deviceNetworkId)
-          			} 
-                    catch(MissingMethodException e) {
-            			if ("${e}".contains('types: (null) values: [null]')) {
-              				log.debug "Device ${child.device.deviceNetworkId} was empty, likely deleted already."
-            			} 
-                        else {
-              				log.error e
-            			}
-          			}
-        		}
-      		}
-    	}
-  	}
+	for (child in children) {
+		for (p in ['stay', 'away']) {
+			if (child.device.deviceNetworkId.contains("dsc${p}")) {
+				def part = child.device.deviceNetworkId.minus("dsc${p}")
+				def jsonPart = partitions.find { x -> x.value."${p}" }
+				if (jsonPart== null) {
+					try {
+						log.debug "Deleting device ${child.device.deviceNetworkId} ${child.device.name} as it was not in the config"
+						deleteChildDevice(child.device.deviceNetworkId)
+					} 
+					catch(MissingMethodException e) {
+						if ("${e}".contains('types: (null) values: [null]')) {
+							log.debug "Device ${child.device.deviceNetworkId} was empty, likely deleted already."
+						} 
+						else {
+							log.error e
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 def sendUrl(url) {
 	
-    log.debug "sendUrl(" + url + ")"
-    def result = new physicalgraph.device.HubAction(
-        method: 'GET',
-        path: "/api/alarm/${url}",
-        headers: [
-            HOST: "${settings.ip}:${settings.port}"
-        ]
-    )
+	log.debug "sendUrl(" + url + ")"
+	def result = new physicalgraph.device.HubAction(
+		method: 'GET',
+		path: "/api/alarm/${url}",
+		headers: [
+			HOST: "${settings.ip}:${settings.port}"
+		]
+	)
 	sendHubCommand(result)
 	log.debug 'response' : "Request to send url: ${url} received"
     
-    return result
+	return result
 }
 
 
 def installed() {
-  	log.debug 'Installed!'
+	log.debug 'Installed!'
 }
 
 def testFunction() {
@@ -291,10 +291,10 @@ def testFunction() {
 }
 
 def updated() {
-  	unsubscribe()
-  	unschedule()
-  	initialize()
-  	log.debug 'Updated!'
+	unsubscribe()
+	unschedule()
+	initialize()
+	log.debug 'Updated!'
 }
 
 private update() {
@@ -305,13 +305,12 @@ private update() {
 	if (update.'parameters') {
 		for (p in update.'parameters') {
 			if (notifyEvents && (notifyEvents.contains('all') || notifyEvents.contains("led ${p.key} ${p.value}".toString()))) {
-            	
-                def messageBody = "Keypad LED ${p.key} in ${p.value} state"
-                
-                if (includePartition == 'Yes')
-                    messageBody += " (Partition: ${update.'value'})"
+				def messageBody = "Keypad LED ${p.key} in ${p.value} state"
+				
+				if (includePartition == 'Yes')
+					messageBody += " (Partition: ${update.'value'})"
                     
-                sendMessage(messageBody)
+				sendMessage(messageBody)
 			}
 		}
 	} 
@@ -320,167 +319,167 @@ private update() {
 	else {
 		if (notifyEvents && (notifyEvents.contains('all') || notifyEvents.contains("${update.'type'} ${update.'status'}".toString()))) {
       		
-            if ("${update.'type'}" == 'partition') {
+			if ("${update.'type'}" == 'partition') {
             
-            	def messageBody = "Alarm in ${update.'status'} state"
+				def messageBody = "Alarm in ${update.'status'} state"
                 
-            	if ("${update.'status'}" == 'alarm')
-                    messageBody = "Alarm is active!"
-                else if ("${update.'status'}" == 'armed')
-                    messageBody = "Alarm is armed"
-                else if ("${update.'status'}" == 'away')
-                    messageBody = "Alarm is armed/away"
-                else if ("${update.'status'}" == 'disarm')
-                    messageBody = "Alarm is disarmed"
-                else if ("${update.'status'}" == 'duress')
-                    messageBody = "Alarm is in a state of duress"
-                else if ("${update.'status'}" == 'entrydelay')
-                    messageBody = "Entry delay in progress"
-                else if ("${update.'status'}" == 'exitdelay')
-                    messageBody = "Exit delay in progress" 
+				if ("${update.'status'}" == 'alarm')
+					messageBody = "Alarm is active!"
+				else if ("${update.'status'}" == 'armed')
+					messageBody = "Alarm is armed"
+				else if ("${update.'status'}" == 'away')
+					messageBody = "Alarm is armed/away"
+				else if ("${update.'status'}" == 'disarm')
+					messageBody = "Alarm is disarmed"
+				else if ("${update.'status'}" == 'duress')
+					messageBody = "Alarm is in a state of duress"
+				else if ("${update.'status'}" == 'entrydelay')
+					messageBody = "Entry delay in progress"
+				else if ("${update.'status'}" == 'exitdelay')
+					messageBody = "Exit delay in progress" 
 				else if ("${update.'status'}" == 'forceready')
-                    messageBody = "Alarm has been forced ready"
+					messageBody = "Alarm has been forced ready"
 				else if ("${update.'status'}" == 'instantaway')
-                    messageBody = "Alarm has been set to instant away"
+					messageBody = "Alarm has been set to instant away"
 				else if ("${update.'status'}" == 'instantstay')
-                    messageBody = "Alarm has been set to instant stay"
+					messageBody = "Alarm has been set to instant stay"
 				else if ("${update.'status'}" == 'notready')
-                    messageBody = "Alarm is not ready"
+					messageBody = "Alarm is not ready"
 				else if ("${update.'status'}" == 'ready')
-                    messageBody = "Alarm is ready"
+					messageBody = "Alarm is ready"
 				else if ("${update.'status'}" == 'restore')
-                    messageBody = "Alarm has been restored"
+					messageBody = "Alarm has been restored"
 				else if ("${update.'status'}" == 'stay')
-                    messageBody = "Alarm is armed/stay"
+					messageBody = "Alarm is armed/stay"
 				else if ("${update.'status'}" == 'trouble')
-                    messageBody = "Alarm has a trouble status"
+					messageBody = "Alarm has a trouble status"
 				else if ("${update.'status'}" == 'keyfirealarm')
-                    messageBody = "Fire alarm key pressed on alarm"
+					messageBody = "Fire alarm key pressed on alarm"
 				else if ("${update.'status'}" == 'keyfirerestore')
-                    messageBody = "Fire alarm key restored on alarm"
+					messageBody = "Fire alarm key restored on alarm"
 				else if ("${update.'status'}" == 'keyauxalarm')
-                    messageBody = "Auxiliary alarm key pressed on alarm"
+					messageBody = "Auxiliary alarm key pressed on alarm"
 				else if ("${update.'status'}" == 'keyauxrestore')
-                    messageBody = "Auxiliary alarm key restored on alarm"
+					messageBody = "Auxiliary alarm key restored on alarm"
 				else if ("${update.'status'}" == 'keypanicalarm')
-                    messageBody = "Panic key pressed on alarm"
+					messageBody = "Panic key pressed on alarm"
 				else if ("${update.'status'}" == 'keypanicrestore')
-                    messageBody = "Panic key restored on alarm"
+					messageBody = "Panic key restored on alarm"
                 
-                if (includePartition == 'Yes')
-                    messageBody += " (Partition: ${update.'value'})"
+				if (includePartition == 'Yes')
+					messageBody += " (Partition: ${update.'value'})"
                     
-                sendMessage(messageBody)
-            }
+				sendMessage(messageBody)
+			}
             
-            else if ("${update.'type'}" == 'zone') {
+			else if ("${update.'type'}" == 'zone') {
             
-                if ("${update.'status'}" == 'clear')
-                    sendMessage("Zone ${update.'value'} is clear")
+				if ("${update.'status'}" == 'clear')
+					sendMessage("Zone ${update.'value'} is clear")
 				else if ("${update.'status'}" == 'closed')
-                    sendMessage("Zone ${update.'value'} is closed")
-                else if ("${update.'status'}" == 'fault')
-                    sendMessage("Zone ${update.'value'} is in fault")
-                else if ("${update.'status'}" == 'open')
-                    sendMessage("Zone ${update.'value'} is open")
-                else if ("${update.'status'}" == 'restore')
-                    sendMessage("Zone ${update.'value'} has been restored")
-                else if ("${update.'status'}" == 'smoke')
-                    sendMessage("Smoke detected in zone ${update.'value'}")
-                else if ("${update.'status'}" == 'tamper')
-                    sendMessage("Zone ${update.'value'} has been tampered with")
-                else
-                    sendMessage("Zone ${update.'value'} in ${update.'status'} state")
-            }
-    	}
-    }
+					sendMessage("Zone ${update.'value'} is closed")
+				else if ("${update.'status'}" == 'fault')
+					sendMessage("Zone ${update.'value'} is in fault")
+				else if ("${update.'status'}" == 'open')
+					sendMessage("Zone ${update.'value'} is open")
+				else if ("${update.'status'}" == 'restore')
+					sendMessage("Zone ${update.'value'} has been restored")
+				else if ("${update.'status'}" == 'smoke')
+					sendMessage("Smoke detected in zone ${update.'value'}")
+				else if ("${update.'status'}" == 'tamper')
+					sendMessage("Zone ${update.'value'} has been tampered with")
+				else
+					sendMessage("Zone ${update.'value'} in ${update.'status'} state")
+			}
+		}
+	}
   
 	if ("${update.'type'}" == 'zone') {
 		updateZoneDevices(update.'value', update.'status')
 	}
   
 	else if ("${update.'type'}" == 'partition') {
-    	if (settings.shmSync == 'Yes') {
-      		// Map DSC states to SHM modes, only using absolute states for now, no exit/entry delay
-      		def shmMap = [
-        		'away':'away',
-        		'forceready':'off',
+		if (settings.shmSync == 'Yes') {
+			// Map DSC states to SHM modes, only using absolute states for now, no exit/entry delay
+			def shmMap = [
+				'away':'away',
+				'forceready':'off',
 				'instantaway':'away',
-        		'instantstay':'stay',
-        		'notready':'off',
-        		'ready':'off',
-        		'stay':'stay',
-      		]
+				'instantstay':'stay',
+				'notready':'off',
+				'ready':'off',
+				'stay':'stay',
+			]
 
-            if (shmMap[update.'status']) {
-                if (settings.shmBypass != 'Yes' || !(location.currentState("alarmSystemStatus")?.value in ['away','stay'] && shmMap[update.'status'] in ['away','stay'])) {
-                    log.debug "sending smart home monitor: ${shmMap[update.'status']} for status: ${update.'status'}"
-                    sendLocationEvent(name: "alarmSystemStatus", value: shmMap[update.'status'])
-                }
-            }
+			if (shmMap[update.'status']) {
+				if (settings.shmBypass != 'Yes' || !(location.currentState("alarmSystemStatus")?.value in ['away','stay'] && shmMap[update.'status'] in ['away','stay'])) {
+					log.debug "sending smart home monitor: ${shmMap[update.'status']} for status: ${update.'status'}"
+					sendLocationEvent(name: "alarmSystemStatus", value: shmMap[update.'status'])
+				}
+			}
 		}
-    	updatePartitions(update.'value', update.'status', update.'parameters')
-  	}
+		updatePartitions(update.'value', update.'status', update.'parameters')
+	}
 }
 
 private updateZoneDevices(zonenum,zonestatus) {
 	
-    def children = getChildDevices()
-  	log.debug "zone: ${zonenum} is ${zonestatus}"
-  	// log.debug "zonedevices.id are $zonedevices.id"
-  	// log.debug "zonedevices.displayName are $zonedevices.displayName"
-  	// log.debug "zonedevices.deviceNetworkId are $zonedevices.deviceNetworkId"
-  	def zonedevice = children.find { item -> item.device.deviceNetworkId == "dsczone${zonenum}"}
-  	//def zonedevice = zonedevices.find { it.deviceNetworkId == "dsczone${zonenum}" }
+	def children = getChildDevices()
+	log.debug "zone: ${zonenum} is ${zonestatus}"
+	// log.debug "zonedevices.id are $zonedevices.id"
+	// log.debug "zonedevices.displayName are $zonedevices.displayName"
+	// log.debug "zonedevices.deviceNetworkId are $zonedevices.deviceNetworkId"
+	def zonedevice = children.find { item -> item.device.deviceNetworkId == "dsczone${zonenum}"}
+	//def zonedevice = zonedevices.find { it.deviceNetworkId == "dsczone${zonenum}" }
   	
-    if (zonedevice) {
-    	log.debug "Was True... Zone Device: $zonedevice.displayName at $zonedevice.deviceNetworkId is ${zonestatus}"
-    	//Was True... Zone Device: Front Door Sensor at zone1 is closed
-    	zonedevice.zone("${zonestatus}")
+	if (zonedevice) {
+		log.debug "Was True... Zone Device: $zonedevice.displayName at $zonedevice.deviceNetworkId is ${zonestatus}"
+		//Was True... Zone Device: Front Door Sensor at zone1 is closed
+		zonedevice.zone("${zonestatus}")
     
-    	if ("${settings.xbmcserver}" != "") {  //Note: I haven't tested this if statement, but it looks like it would work.
-      		def lanaddress = "${settings.xbmcserver}:${settings.xbmcport}"
-      		def deviceNetworkId = "1234"
-      		def json = new JsonBuilder()
-      		def messagetitle = "$zonedevice.displayName".replaceAll(' ','%20')
-      		log.debug "$messagetitle"
-      		json.call("jsonrpc":"2.0","method":"GUI.ShowNotification","params":[title: "$messagetitle",message: "${zonestatus}"],"id":1)
-      		def xbmcmessage = "/jsonrpc?request="+json.toString()
-      		def result = new physicalgraph.device.HubAction("""GET $xbmcmessage HTTP/1.1\r\nHOST: $lanaddress\r\n\r\n""", physicalgraph.device.Protocol.LAN, "${deviceNetworkId}")
-      		sendHubCommand(result)
-    	}
-  	}
+		if ("${settings.xbmcserver}" != "") {  //Note: I haven't tested this if statement, but it looks like it would work.
+			def lanaddress = "${settings.xbmcserver}:${settings.xbmcport}"
+			def deviceNetworkId = "1234"
+			def json = new JsonBuilder()
+			def messagetitle = "$zonedevice.displayName".replaceAll(' ','%20')
+			log.debug "$messagetitle"
+			json.call("jsonrpc":"2.0","method":"GUI.ShowNotification","params":[title: "$messagetitle",message: "${zonestatus}"],"id":1)
+			def xbmcmessage = "/jsonrpc?request="+json.toString()
+			def result = new physicalgraph.device.HubAction("""GET $xbmcmessage HTTP/1.1\r\nHOST: $lanaddress\r\n\r\n""", physicalgraph.device.Protocol.LAN, "${deviceNetworkId}")
+			sendHubCommand(result)
+		}
+	}
 }
 
 private updatePartitions(partitionnum, partitionstatus, partitionparams) {
 	
-    def children = getChildDevices()
-  	log.debug "partition: ${partitionnum} is ${partitionstatus}"
+	def children = getChildDevices()
+	log.debug "partition: ${partitionnum} is ${partitionstatus}"
   	
-    def awaypanel = children.find { item -> item.device.deviceNetworkId == "dscaway${partitionnum}"}
-  	if (awaypanel) {
-    	log.debug "Was True... Away Switch device: $awaypanel.displayName at $awaypanel.deviceNetworkId is ${partitionstatus}"
-    	//Was True... Zone Device: Front Door Sensor at zone1 is closed
-    	awaypanel.partition("${partitionstatus}", "${partitionnum}", partitionparams)
-  	}
+	def awaypanel = children.find { item -> item.device.deviceNetworkId == "dscaway${partitionnum}"}
+	if (awaypanel) {
+		log.debug "Was True... Away Switch device: $awaypanel.displayName at $awaypanel.deviceNetworkId is ${partitionstatus}"
+		//Was True... Zone Device: Front Door Sensor at zone1 is closed
+		awaypanel.partition("${partitionstatus}", "${partitionnum}", partitionparams)
+	}
   	
-    def staypanel = children.find { item -> item.device.deviceNetworkId == "dscstay${partitionnum}"}
-  	if (staypanel) {
-    	log.debug "Was True... Stay Switch device: $staypanel.displayName at $staypanel.deviceNetworkId is ${partitionstatus}"
-    	//Was True... Zone Device: Front Door Sensor at zone1 is closed
-    	staypanel.partition("${partitionstatus}", "${partitionnum}", partitionparams)
-  	}
+	def staypanel = children.find { item -> item.device.deviceNetworkId == "dscstay${partitionnum}"}
+	if (staypanel) {
+		log.debug "Was True... Stay Switch device: $staypanel.displayName at $staypanel.deviceNetworkId is ${partitionstatus}"
+		//Was True... Zone Device: Front Door Sensor at zone1 is closed
+		staypanel.partition("${partitionstatus}", "${partitionnum}", partitionparams)
+	}
 }
 
 private sendMessage(msg) {
 	
-    def newMsg = "Alarm Notification: $msg"
+	def newMsg = "Alarm Notification: $msg"
   	
-    if (phone1) {
-	    sendSms(phone1, newMsg)
-  	}
+	if (phone1) {
+		sendSms(phone1, newMsg)
+	}
   	
-    if (sendPush == 'Yes') {
-    	sendPush(newMsg)
-  	}
+	if (sendPush == 'Yes') {
+		sendPush(newMsg)
+	}
 }

--- a/smartapps/dsc/dsc-integration.src/dsc-integration.groovy
+++ b/smartapps/dsc/dsc-integration.src/dsc-integration.groovy
@@ -6,10 +6,10 @@
  *  Modified by: Jordan <jordan@xeron.cc>
  *  Modified by: Mike Maat <mmaat@ualberta.ca> on 2016-04-08
  *		Changes:	Added Flood Sensor Type (define a flood sensor (DSC WS4985) in alarmserver.cfg as 'flood'
- *					Fixed line identation
- *					Customized alarm push messages to be more understandable for end users
- *					Added a setting to show/not show partition number in notification messages
- *					Fixed "notification" spelling error on line 46
+ *				Fixed line identation
+ *				Customized alarm push messages to be more understandable for end users
+ *				Added a setting to show/not show partition number in notification messages
+ *				Fixed "notification" spelling error on line 46
  */
 
 definition(


### PR DESCRIPTION
Changes are as follows:
- Changed the tile layout of all the device types to use "multiAttributeTile"
- Simplified the Stay and Away panel looks. The majority of people will only need a few buttons. The previous buttons have been retained but commented out
- Added a "flood" device type in the alarmserver.cfg and a flood device type handler. This mimics a contact device for use with DSC water sensors (WS4985) but cosmetically skins it as a water sensor and allows it to be used elsewhere (SHM, etc.) as a water sensor
- Added message text for each type of alarm push notification to make the messages more readable and user friendly
- Added a yes/no toggle for including partition number in push notifications. Most users will only have one partition, so the partition number is irrelevant
![img_3052](https://cloud.githubusercontent.com/assets/5282213/14437103/f10996f0-ffdc-11e5-9af1-72aae06d682e.PNG)
![img_3053](https://cloud.githubusercontent.com/assets/5282213/14437104/f10a02c0-ffdc-11e5-9113-e7b164bff8ee.PNG)
![img_3055](https://cloud.githubusercontent.com/assets/5282213/14437102/f108e9e4-ffdc-11e5-854b-2eadb6193930.PNG)
![img_3056](https://cloud.githubusercontent.com/assets/5282213/14437101/f108c5ae-ffdc-11e5-88e3-ca3583ea08fb.PNG)
![img_3057](https://cloud.githubusercontent.com/assets/5282213/14437100/f10845d4-ffdc-11e5-9acb-3147df370249.PNG)




